### PR TITLE
flowdockhashtag: Fix .match is not a function critical error

### DIFF
--- a/lib/services/messenger/translators/flowdockhashtag.ts
+++ b/lib/services/messenger/translators/flowdockhashtag.ts
@@ -145,7 +145,15 @@ export class FlowdockHashtagTranslator extends FlowdockTranslator implements Tra
 			const firstMessageDetails = this.eventIntoMessageDetails(firstMessageAsEvent);
 			const hashtags: string[] = [];
 			_.forEach(fetchedDetails.messages, (message) => {
-				_.forEach(message.content.match(/#\w+/g), (match) => {
+				// Flowdock may report a wide variety of event types,
+				// but we're only interested in messages.
+				// See https://www.flowdock.com/api/message-types
+				if (message.event !== 'message' || message.event !== 'message-edit') {
+					return;
+				}
+
+				const content = message.content.updated_content || message.content
+				_.forEach(content.match(/#\w+/g), (match) => {
 					hashtags.push(match.replace(/^#/, ''));
 				});
 			});


### PR DESCRIPTION
We found this because of this error: `TypeError: message.content.match
is not a function`.

The problem is that in various event types, `content` is not a string,
but an object. See https://www.flowdock.com/api/message-types for
examples.

We believe this ended up causing some messages to be lost when syncing
from Front to Flowdock.

Change-type: patch
