### PR TITLE
syncbot: Better detect if an event represents an error

### DIFF
--- a/lib/bots/syncbot.ts
+++ b/lib/bots/syncbot.ts
@@ -385,7 +385,7 @@ export class SyncBot extends ProcBot {
 				// At the end report any errors. ProcBot only expects promise resolution, no actual payload.
 				// This also bookends the promise chain so each .then() above can be developed atomically.
 				.then((threadDetails: MessengerEmitResponse) => {
-					if (threadDetails.err) {
+					if (!_.isEmpty(threadDetails.err)) {
 						logger.log(LogLevel.WARN, JSON.stringify({
 							// Details of the message and the response
 							data, threadDetails,


### PR DESCRIPTION
I'm not sure why, but there are some correct events whose `err`
property gets set to an empty object. These events don't represent any
error, but the logic that checks if something is an error just casts the
value to boolean, which means an empty object is evaluated to true, and
therefore syncbot things its an error, and will not sync it back
correctly.

Change-type: patch