### PR TITLE
Print error response on Flowdock API errors

### DIFF
--- a/lib/services/flowdock.ts
+++ b/lib/services/flowdock.ts
@@ -91,7 +91,12 @@ export class FlowdockService extends ServiceScaffold<string> implements ServiceE
 				context.data.path, context.data.payload,
 				(error: Error, response: FlowdockResponse) => {
 					if (error) {
-						reject(error);
+						try {
+							// Attempt to stringify response so that the full object is printed on error
+							response = JSON.stringify(response);
+						} finally {
+							reject(new Error(`${error}: ${response}`));
+						}
 					} else {
 						resolve(response);
 					}


### PR DESCRIPTION

    
 This is to help debugging errors with the Flowdock API, because at the moment the only info we get is messages like:
    
```
Error in Flowdock service. Error - Received status 400
```    

The flowdock API returns a more descriptive message even on errors, e.g.

```
"{"message":"Validation error","errors":{"content":["is too long(maximum length is 8096 characters)"]}}"
```
    
and that will help us narrow down which requests are malformed and why.

Change-type: patch
Singed-off-by: Kostas Lekkas <kostas@balena.io>