### PR TITLE
Vendor Flowdock fork to facilitate debugging

### DIFF
--- a/lib/services/flowdock.ts
+++ b/lib/services/flowdock.ts
@@ -95,6 +95,7 @@ export class FlowdockService extends ServiceScaffold<string> implements ServiceE
 							// Attempt to stringify response so that the full object is printed on error
 							response = JSON.stringify(response);
 						} finally {
+							this.logger.log(LogLevel.DEBUG, `Error in emitData with response: ${response}`);
 							reject(new Error(`${error}: ${response}`));
 						}
 					} else {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "colors": "^1.1.2",
     "emailreplyparser": "0.0.5",
     "express": "^4.0.34",
-    "flowdock": "^0.9.1",
+    "flowdock": "github:balena-io-playground/node-flowdock#emit-error-response",
     "front-sdk": "^0.3.1",
     "github": "9.2.0",
     "github-webhook-handler": "^0.6.0",


### PR DESCRIPTION
The official Flowdock npm module does not emit enough information when
an error has occured in the session.

The temporary solution here is to create a fork, that will emit more
information, like error body and request path/body, so that we can
continue debugging syncbot issues with more data.

For the full changelog in the forked flowdock library check https://github.com/balena-io-playground/node-flowdock/commit/e5de9c697d554fb81714ffb4e3e41d43bbe3e0b3

In a second phase, after we debug the high priority syncbot errors, we
will merge the flowdock PR and submit a patch

Change-type: patch
Singed-off-by: Kostas Lekkas <kostas@balena.io>
