### PR TITLE
Log Front events to solve intercomHack: true issue

### DIFF
--- a/lib/services/messenger/translators/discourse.ts
+++ b/lib/services/messenger/translators/discourse.ts
@@ -376,7 +376,7 @@ export class DiscourseTranslator extends TranslatorScaffold implements Translato
 	}
 
 	protected eventEquivalencies = {
-		message: ['post_created', 'post_edited'],
+		message: ['post_created']
 	};
 	protected emitConverters: EmitConverters = {
 		[MessengerAction.ReadConnection]: DiscourseTranslator.searchThreadIntoEmit,

--- a/lib/services/messenger/translators/discourse.ts
+++ b/lib/services/messenger/translators/discourse.ts
@@ -454,7 +454,7 @@ export class DiscourseTranslator extends TranslatorScaffold implements Translato
 				// If this is an edit, then create a murmur to that effect
 				case 'post_edited':
 					metadata = TranslatorScaffold.emptyMetadata(`This thread was edited by ${convertedUsername}.`);
-					metadata.hidden = true;
+					metadata.hidden = 'preferred';
 					break;
 				// Find the metadata from the post created
 				default:
@@ -509,7 +509,7 @@ export class DiscourseTranslator extends TranslatorScaffold implements Translato
 					},
 					message: {
 						// post_type 4 seems to correspond to whisper
-						hidden: !_.isNil(metadata.hidden) ? metadata.hidden : details.post.post_type === 4,
+						hidden: _.isSet(metadata.hidden) ? metadata.hidden : details.post.post_type === 4,
 						text: TranslatorScaffold.convertPings(codeParsedText, DiscourseTranslator.convertUsernameToGeneric),
 						time: details.post.created_at,
 					}

--- a/lib/services/messenger/translators/front.ts
+++ b/lib/services/messenger/translators/front.ts
@@ -175,7 +175,7 @@ export class FrontTranslator extends TranslatorScaffold implements Translator {
 	 * @returns        Promise that resolves to the name of the author.
 	 */
 	private static fetchAuthorName(session: Front, event: Event): Promise<string> {
-		if (event.source._meta.type === 'teammate') {
+		if (event.source._meta.type === 'teammate' && !_.isNil(event.source.data) && !_.isNil(event.source.data.username)) {
 			return Promise.resolve(FrontTranslator.convertUsernameToGeneric(event.source.data.username));
 		}
 		const target = _.get(event, ['target', 'data'], {});

--- a/lib/services/messenger/translators/front.ts
+++ b/lib/services/messenger/translators/front.ts
@@ -34,6 +34,7 @@ import {
 import * as _ from 'lodash';
 import * as marked from 'marked';
 import * as moment from 'moment';
+import { Logger, LogLevel } from '../../../utils/logger';
 import { FrontConstructor, FrontEmitInstructions, FrontResponse, FrontServiceEvent } from '../../front-types';
 import {
 	BasicEventInformation,
@@ -566,9 +567,11 @@ export class FrontTranslator extends TranslatorScaffold implements Translator {
 
 	private readonly session: Front;
 	private readonly token: string;
+	private loggerInstance: Logger;
 
 	constructor(data: FrontConstructor, metadataConfig: MetadataConfiguration) {
 		super(metadataConfig);
+		this.loggerInstance = new Logger();
 		this.session = new Front(data.token);
 		this.token = data.token;
 		this.responseConverters[MessengerAction.CreateThread] =
@@ -593,6 +596,9 @@ export class FrontTranslator extends TranslatorScaffold implements Translator {
 	 * @returns      Promise that resolves to an array of message objects in the standard form
 	 */
 	public eventIntoMessages(event: FrontServiceEvent): Promise<MessengerEvent[]> {
+		this.loggerInstance.log(LogLevel.INFO, 'Logging Front event');
+		this.loggerInstance.log(LogLevel.INFO, JSON.stringify(event));
+
 		const rawEvent: any = event.rawEvent;
 		return Promise.props({
 			inboxes: this.session.conversation.listInboxes({conversation_id: rawEvent.conversation.id}),
@@ -610,6 +616,8 @@ export class FrontTranslator extends TranslatorScaffold implements Translator {
 			subject: string,
 			author: string
 		}) => {
+			this.loggerInstance.log(LogLevel.INFO, 'Logging Front details for event');
+			this.loggerInstance.log(LogLevel.INFO, JSON.stringify(details));
 			// Extract some details from the event.
 			const hidden = _.includes(['comment', 'mention'], details.event.type);
 			const metadataFormat = hidden ? MetadataEncoding.HiddenMD : MetadataEncoding.HiddenHTML;


### PR DESCRIPTION
intercomHack property is set to true in some events, which results in messages not propagating from Front to flowdock. With this PR we'll log more information that will aid with debugging.

In this PR we piggyback a few fixes for problems that are causing noise, like:

- Don't handle 'post_edited' events
- Resolve `Unhandled rejection TypeError: Cannot read property 'username' of null"` issue 

Change-type: patch
Signed-off-by: Kostas Lekkas <kostas@balena.io>
