### PR TITLE
Workaround for missed Front -> FD messages

### DIFF
--- a/lib/services/messenger/translators/front.ts
+++ b/lib/services/messenger/translators/front.ts
@@ -670,7 +670,7 @@ export class FrontTranslator extends TranslatorScaffold implements Translator {
 				},
 				current: {
 					// https://github.com/resin-io-modules/resin-procbots/issues/301
-					intercomHack: isIntercom ? details.event.conversation.subject !== '' : undefined,
+					intercomHack: isIntercom ? details.event.conversation.subject.replace(/^Re:\s+/, '') !== '' : undefined,
 					service: event.source,
 					message: details.event.id,
 					flow: 'duff_FrontTranslator_eventIntoMessages_a', // Gets replaced


### PR DESCRIPTION
There's an assumption stated at
https://github.com/balena-io-modules/resin-procbots/issues/301, that

>  an event inputted in Front/Intercom has an empty subject property, where an event inputted from Flowdock with a subject property retains that.

This is only half-true, as events in Front/Intercom sometimes have a
'Re: ' title that breaks the sync. We've still haven't gotten to the
bottom of when/why it happens, but this temporary fix should be enough to prevent lost
messages given that the 'Re: ' behaviour is consistent.

Change-type: patch
Signed-off-by: Kostas Lekkas <kostas@balena.io>
