### PR TITLE
Update front-sdk dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,44 +4,44 @@
   "dependencies": {
     "@gulp-sourcemaps/identity-map": {
       "version": "1.0.2",
-      "from": "@gulp-sourcemaps/identity-map@>=1.0.0 <2.0.0",
+      "from": "@gulp-sourcemaps/identity-map@1.X",
       "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-1.0.2.tgz",
       "dev": true
     },
     "@gulp-sourcemaps/map-sources": {
       "version": "1.0.0",
-      "from": "@gulp-sourcemaps/map-sources@>=1.0.0 <2.0.0",
+      "from": "@gulp-sourcemaps/map-sources@1.X",
       "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
       "dev": true
     },
     "@octokit/rest": {
       "version": "15.18.1",
-      "from": "@octokit/rest@>=15.10.0 <16.0.0",
+      "from": "@octokit/rest@^15.10.0",
       "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.18.1.tgz",
       "dependencies": {
         "agent-base": {
           "version": "4.2.1",
-          "from": "agent-base@>=4.1.0 <5.0.0",
+          "from": "agent-base@^4.1.0",
           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz"
         },
         "debug": {
           "version": "3.2.6",
-          "from": "debug@>=3.1.0 <4.0.0",
+          "from": "debug@^3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz"
         },
         "https-proxy-agent": {
           "version": "2.2.1",
-          "from": "https-proxy-agent@>=2.2.0 <3.0.0",
+          "from": "https-proxy-agent@^2.2.0",
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz"
         },
         "ms": {
           "version": "2.1.1",
-          "from": "ms@>=2.1.1 <3.0.0",
+          "from": "ms@^2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz"
         },
         "node-fetch": {
           "version": "2.3.0",
-          "from": "node-fetch@>=2.1.1 <3.0.0",
+          "from": "node-fetch@^2.1.1",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz"
         }
       }
@@ -58,7 +58,7 @@
     },
     "@resin.io/types-node-localstorage": {
       "version": "1.3.0",
-      "from": "@resin.io/types-node-localstorage@>=1.3.0 <2.0.0",
+      "from": "@resin.io/types-node-localstorage@^1.3.0",
       "resolved": "https://registry.npmjs.org/@resin.io/types-node-localstorage/-/types-node-localstorage-1.3.0.tgz"
     },
     "@types/bluebird": {
@@ -68,7 +68,7 @@
     },
     "@types/bluebird-global": {
       "version": "3.5.10",
-      "from": "@types/bluebird-global@>=3.0.1 <4.0.0",
+      "from": "@types/bluebird-global@^3.0.1",
       "resolved": "https://registry.npmjs.org/@types/bluebird-global/-/bluebird-global-3.5.10.tgz"
     },
     "@types/body-parser": {
@@ -84,13 +84,13 @@
     },
     "@types/chai": {
       "version": "4.1.7",
-      "from": "@types/chai@>=4.0.5 <5.0.0",
+      "from": "@types/chai@^4.0.5",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
       "dev": true
     },
     "@types/chai-as-promised": {
       "version": "7.1.0",
-      "from": "@types/chai-as-promised@>=7.1.0 <8.0.0",
+      "from": "@types/chai-as-promised@^7.1.0",
       "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.0.tgz",
       "dev": true
     },
@@ -107,7 +107,7 @@
     },
     "@types/express": {
       "version": "4.16.1",
-      "from": "@types/express@>=4.0.35 <5.0.0",
+      "from": "@types/express@^4.0.35",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.1.tgz",
       "dependencies": {
         "@types/body-parser": {
@@ -129,13 +129,13 @@
     },
     "@types/fs-extra": {
       "version": "3.0.3",
-      "from": "@types/fs-extra@>=3.0.0 <4.0.0",
+      "from": "@types/fs-extra@^3.0.0",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-3.0.3.tgz",
       "dev": true
     },
     "@types/github": {
       "version": "0.0.0",
-      "from": "@types/github@>=0.0.0 <0.0.1",
+      "from": "@types/github@^0.0.0",
       "resolved": "https://registry.npmjs.org/@types/github/-/github-0.0.0.tgz",
       "dev": true
     },
@@ -147,19 +147,19 @@
     },
     "@types/handlebars": {
       "version": "4.0.40",
-      "from": "@types/handlebars@>=4.0.31 <5.0.0",
+      "from": "@types/handlebars@^4.0.31",
       "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.40.tgz",
       "dev": true
     },
     "@types/highlight.js": {
       "version": "9.12.3",
-      "from": "@types/highlight.js@>=9.1.8 <10.0.0",
+      "from": "@types/highlight.js@^9.1.8",
       "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.3.tgz",
       "dev": true
     },
     "@types/html-entities": {
       "version": "1.2.16",
-      "from": "@types/html-entities@>=1.2.16 <2.0.0",
+      "from": "@types/html-entities@^1.2.16",
       "resolved": "https://registry.npmjs.org/@types/html-entities/-/html-entities-1.2.16.tgz",
       "dev": true
     },
@@ -170,23 +170,23 @@
     },
     "@types/jsonwebtoken": {
       "version": "7.2.8",
-      "from": "@types/jsonwebtoken@>=7.2.0 <8.0.0",
+      "from": "@types/jsonwebtoken@^7.2.0",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.8.tgz",
       "dev": true
     },
     "@types/jwt-decode": {
       "version": "2.2.1",
-      "from": "@types/jwt-decode@>=2.2.1 <3.0.0",
+      "from": "@types/jwt-decode@^2.2.1",
       "resolved": "https://registry.npmjs.org/@types/jwt-decode/-/jwt-decode-2.2.1.tgz"
     },
     "@types/lodash": {
       "version": "4.14.121",
-      "from": "@types/lodash@>=4.14.54 <5.0.0",
+      "from": "@types/lodash@^4.14.54",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.121.tgz"
     },
     "@types/lodash.memoize": {
       "version": "4.1.5",
-      "from": "@types/lodash.memoize@>=4.1.2 <5.0.0",
+      "from": "@types/lodash.memoize@^4.1.2",
       "resolved": "https://registry.npmjs.org/@types/lodash.memoize/-/lodash.memoize-4.1.5.tgz"
     },
     "@types/marked": {
@@ -202,24 +202,24 @@
     },
     "@types/minimatch": {
       "version": "2.0.29",
-      "from": "@types/minimatch@>=2.0.29 <3.0.0",
+      "from": "@types/minimatch@^2.0.29",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.29.tgz",
       "dev": true
     },
     "@types/mocha": {
       "version": "2.2.48",
-      "from": "@types/mocha@>=2.2.44 <3.0.0",
+      "from": "@types/mocha@^2.2.44",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
       "dev": true
     },
     "@types/node": {
       "version": "6.14.3",
-      "from": "@types/node@>=6.0.48 <7.0.0",
+      "from": "@types/node@^6.0.48",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.3.tgz"
     },
     "@types/node-getopt": {
       "version": "0.2.31",
-      "from": "@types/node-getopt@>=0.2.29 <0.3.0",
+      "from": "@types/node-getopt@^0.2.29",
       "resolved": "https://registry.npmjs.org/@types/node-getopt/-/node-getopt-0.2.31.tgz",
       "dev": true
     },
@@ -230,17 +230,17 @@
     },
     "@types/request": {
       "version": "2.48.1",
-      "from": "@types/request@>=2.48.1 <3.0.0",
+      "from": "@types/request@^2.48.1",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.1.tgz"
     },
     "@types/request-promise": {
       "version": "4.1.42",
-      "from": "@types/request-promise@>=4.1.42 <5.0.0",
+      "from": "@types/request-promise@^4.1.42",
       "resolved": "https://registry.npmjs.org/@types/request-promise/-/request-promise-4.1.42.tgz"
     },
     "@types/semver": {
       "version": "5.5.0",
-      "from": "@types/semver@>=5.4.0 <6.0.0",
+      "from": "@types/semver@^5.4.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz"
     },
     "@types/serve-static": {
@@ -250,7 +250,7 @@
     },
     "@types/shelljs": {
       "version": "0.7.9",
-      "from": "@types/shelljs@>=0.7.0 <0.8.0",
+      "from": "@types/shelljs@^0.7.0",
       "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.7.9.tgz",
       "dev": true
     },
@@ -261,62 +261,62 @@
     },
     "abbrev": {
       "version": "1.1.1",
-      "from": "abbrev@>=1.0.0 <2.0.0",
+      "from": "abbrev@1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz"
     },
     "accepts": {
       "version": "1.3.5",
-      "from": "accepts@>=1.3.5 <1.4.0",
+      "from": "accepts@~1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz"
     },
     "acorn": {
       "version": "5.7.3",
-      "from": "acorn@>=5.0.0 <6.0.0",
+      "from": "acorn@5.X",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
       "dev": true
     },
     "agent-base": {
       "version": "2.1.1",
-      "from": "agent-base@>=2.0.0 <3.0.0",
+      "from": "agent-base@2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
       "dependencies": {
         "extend": {
           "version": "3.0.2",
-          "from": "extend@>=3.0.0 <3.1.0",
+          "from": "extend@~3.0.0",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
         }
       }
     },
     "agentkeepalive": {
       "version": "3.5.2",
-      "from": "agentkeepalive@>=3.1.0 <4.0.0",
+      "from": "agentkeepalive@^3.1.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz"
     },
     "ajv": {
       "version": "6.9.2",
-      "from": "ajv@>=6.5.5 <7.0.0",
+      "from": "ajv@^6.5.5",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz"
     },
     "ansi-align": {
       "version": "2.0.0",
-      "from": "ansi-align@>=2.0.0 <3.0.0",
+      "from": "ansi-align@^2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
       "dev": true
     },
     "ansi-gray": {
       "version": "0.1.1",
-      "from": "ansi-gray@>=0.1.1 <0.2.0",
+      "from": "ansi-gray@^0.1.1",
       "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
       "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
-      "from": "ansi-regex@>=2.0.0 <3.0.0",
+      "from": "ansi-regex@^2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "from": "ansi-styles@>=2.2.1 <3.0.0",
+      "from": "ansi-styles@^2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
     },
     "ansi-wrap": {
@@ -327,57 +327,57 @@
     },
     "archy": {
       "version": "1.0.0",
-      "from": "archy@>=1.0.0 <2.0.0",
+      "from": "archy@^1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "dev": true
     },
     "argparse": {
       "version": "1.0.10",
-      "from": "argparse@>=1.0.7 <2.0.0",
+      "from": "argparse@^1.0.7",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz"
     },
     "arr-diff": {
       "version": "2.0.0",
-      "from": "arr-diff@>=2.0.0 <3.0.0",
+      "from": "arr-diff@^2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
     },
     "arr-filter": {
       "version": "1.1.2",
-      "from": "arr-filter@>=1.1.1 <2.0.0",
+      "from": "arr-filter@^1.1.1",
       "resolved": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
       "dependencies": {
         "kind-of": {
           "version": "6.0.2",
-          "from": "kind-of@>=6.0.2 <7.0.0",
+          "from": "kind-of@^6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz"
         },
         "make-iterator": {
           "version": "1.0.1",
-          "from": "make-iterator@>=1.0.0 <2.0.0",
+          "from": "make-iterator@^1.0.0",
           "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz"
         }
       }
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "from": "arr-flatten@>=1.0.1 <2.0.0",
+      "from": "arr-flatten@^1.0.1",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz"
     },
     "arr-union": {
       "version": "3.1.0",
-      "from": "arr-union@>=3.1.0 <4.0.0",
+      "from": "arr-union@^3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "dev": true
     },
     "array-differ": {
       "version": "1.0.0",
-      "from": "array-differ@>=1.0.0 <2.0.0",
+      "from": "array-differ@^1.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
       "dev": true
     },
     "array-each": {
       "version": "1.0.1",
-      "from": "array-each@>=1.0.1 <2.0.0",
+      "from": "array-each@^1.0.1",
       "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
       "dev": true
     },
@@ -388,17 +388,17 @@
     },
     "array-slice": {
       "version": "0.2.3",
-      "from": "array-slice@>=0.2.3 <0.3.0",
+      "from": "array-slice@^0.2.3",
       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
     },
     "array-sort": {
       "version": "0.1.4",
-      "from": "array-sort@>=0.1.2 <0.2.0",
+      "from": "array-sort@^0.1.2",
       "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-0.1.4.tgz",
       "dependencies": {
         "kind-of": {
           "version": "5.1.0",
-          "from": "kind-of@>=5.0.2 <6.0.0",
+          "from": "kind-of@^5.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz"
         }
       }
@@ -410,12 +410,12 @@
     },
     "array-unique": {
       "version": "0.2.1",
-      "from": "array-unique@>=0.2.1 <0.3.0",
+      "from": "array-unique@^0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
     },
     "arrify": {
       "version": "1.0.1",
-      "from": "arrify@>=1.0.0 <2.0.0",
+      "from": "arrify@^1.0.0",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "dev": true
     },
@@ -426,60 +426,60 @@
     },
     "assert-plus": {
       "version": "0.1.5",
-      "from": "assert-plus@>=0.1.5 <0.2.0",
+      "from": "assert-plus@^0.1.5",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
     },
     "assertion-error": {
       "version": "1.1.0",
-      "from": "assertion-error@>=1.1.0 <2.0.0",
+      "from": "assertion-error@^1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
-      "from": "assign-symbols@>=1.0.0 <2.0.0",
+      "from": "assign-symbols@^1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "dev": true
     },
     "ast-types": {
       "version": "0.12.2",
-      "from": "ast-types@>=0.0.0 <1.0.0",
+      "from": "ast-types@0.x.x",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.12.2.tgz"
     },
     "async": {
       "version": "2.6.2",
-      "from": "async@>=2.0.1 <3.0.0",
+      "from": "async@^2.0.1",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz"
     },
     "asynckit": {
       "version": "0.4.0",
-      "from": "asynckit@>=0.4.0 <0.5.0",
+      "from": "asynckit@^0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
     },
     "atob": {
       "version": "2.1.2",
-      "from": "atob@>=2.1.1 <3.0.0",
+      "from": "atob@^2.1.1",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "dev": true
     },
     "autolinker": {
       "version": "0.15.3",
-      "from": "autolinker@>=0.15.0 <0.16.0",
+      "from": "autolinker@~0.15.0",
       "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.15.3.tgz"
     },
     "aws-sign2": {
       "version": "0.5.0",
-      "from": "aws-sign2@>=0.5.0 <0.6.0",
+      "from": "aws-sign2@~0.5.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
     },
     "aws4": {
       "version": "1.8.0",
-      "from": "aws4@>=1.8.0 <2.0.0",
+      "from": "aws4@^1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz"
     },
     "babel-code-frame": {
       "version": "6.26.0",
-      "from": "babel-code-frame@>=6.20.0 <7.0.0",
+      "from": "babel-code-frame@^6.20.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "dev": true
     },
@@ -491,48 +491,48 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "from": "balanced-match@>=1.0.0 <2.0.0",
+      "from": "balanced-match@^1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
     },
     "base": {
       "version": "0.11.2",
-      "from": "base@>=0.11.1 <0.12.0",
+      "from": "base@^0.11.1",
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "dev": true,
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "from": "define-property@>=1.0.0 <2.0.0",
+          "from": "define-property@^1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "dev": true
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "from": "is-accessor-descriptor@>=1.0.0 <2.0.0",
+          "from": "is-accessor-descriptor@^1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "dev": true
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "from": "is-data-descriptor@>=1.0.0 <2.0.0",
+          "from": "is-data-descriptor@^1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "dev": true
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "from": "is-descriptor@>=1.0.0 <2.0.0",
+          "from": "is-descriptor@^1.0.0",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "dev": true
         },
         "isobject": {
           "version": "3.0.1",
-          "from": "isobject@>=3.0.1 <4.0.0",
+          "from": "isobject@^3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "dev": true
         },
         "kind-of": {
           "version": "6.0.2",
-          "from": "kind-of@>=6.0.2 <7.0.0",
+          "from": "kind-of@^6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "dev": true
         }
@@ -540,84 +540,84 @@
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+      "from": "bcrypt-pbkdf@^1.0.0",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz"
     },
     "beeper": {
       "version": "1.1.1",
-      "from": "beeper@>=1.0.0 <2.0.0",
+      "from": "beeper@^1.0.0",
       "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
       "dev": true
     },
     "before-after-hook": {
       "version": "1.3.2",
-      "from": "before-after-hook@>=1.1.0 <2.0.0",
+      "from": "before-after-hook@^1.1.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.3.2.tgz"
     },
     "bl": {
       "version": "0.9.5",
-      "from": "bl@>=0.9.0 <0.10.0",
+      "from": "bl@~0.9.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz"
     },
     "bluebird": {
       "version": "3.5.3",
-      "from": "bluebird@>=3.5.0 <4.0.0",
+      "from": "bluebird@^3.5.0",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz"
     },
     "bluebird-lru-cache": {
       "version": "1.0.1",
-      "from": "bluebird-lru-cache@>=1.0.0 <2.0.0",
+      "from": "bluebird-lru-cache@^1.0.0",
       "resolved": "https://registry.npmjs.org/bluebird-lru-cache/-/bluebird-lru-cache-1.0.1.tgz",
       "dependencies": {
         "lru-cache": {
           "version": "3.2.0",
-          "from": "lru-cache@>=3.2.0 <4.0.0",
+          "from": "lru-cache@^3.2.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz"
         },
         "typed-error": {
           "version": "2.0.0",
-          "from": "typed-error@>=2.0.0 <3.0.0",
+          "from": "typed-error@^2.0.0",
           "resolved": "https://registry.npmjs.org/typed-error/-/typed-error-2.0.0.tgz"
         }
       }
     },
     "body-parser": {
       "version": "1.18.3",
-      "from": "body-parser@>=1.17.1 <2.0.0",
+      "from": "body-parser@^1.17.1",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz"
     },
     "boom": {
       "version": "2.10.1",
-      "from": "boom@>=2.0.0 <3.0.0",
+      "from": "boom@2.x.x",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
     },
     "boxen": {
       "version": "1.3.0",
-      "from": "boxen@>=1.2.1 <2.0.0",
+      "from": "boxen@^1.2.1",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
       "dev": true,
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "from": "ansi-styles@>=3.2.1 <4.0.0",
+          "from": "ansi-styles@^3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
-          "from": "camelcase@>=4.0.0 <5.0.0",
+          "from": "camelcase@^4.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
           "dev": true
         },
         "chalk": {
           "version": "2.4.2",
-          "from": "chalk@>=2.0.1 <3.0.0",
+          "from": "chalk@^2.0.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
-          "from": "supports-color@>=5.3.0 <6.0.0",
+          "from": "supports-color@^5.3.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "dev": true
         }
@@ -625,12 +625,12 @@
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "from": "brace-expansion@>=1.1.7 <2.0.0",
+      "from": "brace-expansion@^1.1.7",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
     },
     "braces": {
       "version": "1.8.5",
-      "from": "braces@>=1.8.2 <2.0.0",
+      "from": "braces@^1.8.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
     },
     "browser-stdout": {
@@ -641,17 +641,17 @@
     },
     "btoa-lite": {
       "version": "1.0.0",
-      "from": "btoa-lite@>=1.0.0 <2.0.0",
+      "from": "btoa-lite@^1.0.0",
       "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz"
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
-      "from": "buffer-equal-constant-time@>=1.0.1 <1.1.0",
+      "from": "buffer-equal-constant-time@~1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
     },
     "buffer-indexof": {
       "version": "1.1.1",
-      "from": "buffer-indexof@>=1.0.0 <2.0.0",
+      "from": "buffer-indexof@^1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz"
     },
     "bytes": {
@@ -661,13 +661,13 @@
     },
     "cache-base": {
       "version": "1.0.1",
-      "from": "cache-base@>=1.0.1 <2.0.0",
+      "from": "cache-base@^1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "dev": true,
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
-          "from": "isobject@>=3.0.1 <4.0.0",
+          "from": "isobject@^3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "dev": true
         }
@@ -675,76 +675,76 @@
     },
     "camelcase": {
       "version": "3.0.0",
-      "from": "camelcase@>=3.0.0 <4.0.0",
+      "from": "camelcase@^3.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
     },
     "capitano": {
       "version": "1.8.2",
-      "from": "capitano@>=1.7.4 <2.0.0",
+      "from": "capitano@^1.7.4",
       "resolved": "https://registry.npmjs.org/capitano/-/capitano-1.8.2.tgz",
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "from": "async@>=1.0.0 <2.0.0",
+          "from": "async@^1.0.0",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         }
       }
     },
     "capture-stack-trace": {
       "version": "1.0.1",
-      "from": "capture-stack-trace@>=1.0.0 <2.0.0",
+      "from": "capture-stack-trace@^1.0.0",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
       "dev": true
     },
     "caseless": {
       "version": "0.10.0",
-      "from": "caseless@>=0.10.0 <0.11.0",
+      "from": "caseless@~0.10.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz"
     },
     "catharsis": {
       "version": "0.8.9",
-      "from": "catharsis@>=0.8.9 <0.9.0",
+      "from": "catharsis@~0.8.9",
       "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
       "dev": true
     },
     "chai": {
       "version": "4.2.0",
-      "from": "chai@>=4.1.2 <5.0.0",
+      "from": "chai@^4.1.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
       "dev": true
     },
     "chai-as-promised": {
       "version": "7.1.1",
-      "from": "chai-as-promised@>=7.1.1 <8.0.0",
+      "from": "chai-as-promised@^7.1.1",
       "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
       "dev": true
     },
     "chalk": {
       "version": "1.1.3",
-      "from": "chalk@>=1.0.0 <2.0.0",
+      "from": "chalk@^1.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
     },
     "check-error": {
       "version": "1.0.2",
-      "from": "check-error@>=1.0.2 <2.0.0",
+      "from": "check-error@^1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "dev": true
     },
     "ci-info": {
       "version": "1.6.0",
-      "from": "ci-info@>=1.5.0 <2.0.0",
+      "from": "ci-info@^1.5.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
       "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
-      "from": "class-utils@>=0.3.5 <0.4.0",
+      "from": "class-utils@^0.3.5",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "dev": true,
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
-          "from": "isobject@>=3.0.0 <4.0.0",
+          "from": "isobject@^3.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "dev": true
         }
@@ -752,56 +752,56 @@
     },
     "cli-boxes": {
       "version": "1.0.0",
-      "from": "cli-boxes@>=1.0.0 <2.0.0",
+      "from": "cli-boxes@^1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
       "dev": true
     },
     "cliui": {
       "version": "3.2.0",
-      "from": "cliui@>=3.2.0 <4.0.0",
+      "from": "cliui@^3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "dependencies": {
         "string-width": {
           "version": "1.0.2",
-          "from": "string-width@>=1.0.1 <2.0.0",
+          "from": "string-width@^1.0.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
         }
       }
     },
     "clone": {
       "version": "1.0.4",
-      "from": "clone@>=1.0.0 <2.0.0",
+      "from": "clone@^1.0.0",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz"
     },
     "clone-stats": {
       "version": "0.0.1",
-      "from": "clone-stats@>=0.0.1 <0.0.2",
+      "from": "clone-stats@^0.0.1",
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
     },
     "co": {
       "version": "4.6.0",
-      "from": "co@>=4.6.0 <5.0.0",
+      "from": "co@^4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
     },
     "code-context": {
       "version": "0.5.3",
-      "from": "code-context@>=0.5.3 <0.6.0",
+      "from": "code-context@^0.5.3",
       "resolved": "https://registry.npmjs.org/code-context/-/code-context-0.5.3.tgz"
     },
     "code-point-at": {
       "version": "1.1.0",
-      "from": "code-point-at@>=1.0.0 <2.0.0",
+      "from": "code-point-at@^1.0.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
     },
     "collection-visit": {
       "version": "1.0.0",
-      "from": "collection-visit@>=1.0.0 <2.0.0",
+      "from": "collection-visit@^1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "dev": true
     },
     "color-convert": {
       "version": "1.9.3",
-      "from": "color-convert@>=1.9.0 <2.0.0",
+      "from": "color-convert@^1.9.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz"
     },
     "color-name": {
@@ -811,28 +811,28 @@
     },
     "color-support": {
       "version": "1.1.3",
-      "from": "color-support@>=1.1.3 <2.0.0",
+      "from": "color-support@^1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "dev": true
     },
     "colors": {
       "version": "1.3.3",
-      "from": "colors@>=1.1.2 <2.0.0",
+      "from": "colors@^1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz"
     },
     "combined-stream": {
       "version": "1.0.7",
-      "from": "combined-stream@>=1.0.1 <1.1.0",
+      "from": "combined-stream@~1.0.1",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz"
     },
     "commander": {
       "version": "2.19.0",
-      "from": "commander@>=2.8.1 <3.0.0",
+      "from": "commander@^2.8.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz"
     },
     "component-emitter": {
       "version": "1.2.1",
-      "from": "component-emitter@>=1.2.0 <2.0.0",
+      "from": "component-emitter@^1.2.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz"
     },
     "concat-map": {
@@ -842,13 +842,13 @@
     },
     "configstore": {
       "version": "3.1.2",
-      "from": "configstore@>=3.0.0 <4.0.0",
+      "from": "configstore@^3.0.0",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
       "dev": true,
       "dependencies": {
         "write-file-atomic": {
           "version": "2.4.2",
-          "from": "write-file-atomic@>=2.0.0 <3.0.0",
+          "from": "write-file-atomic@^2.0.0",
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
           "dev": true
         }
@@ -861,12 +861,12 @@
     },
     "content-type": {
       "version": "1.0.4",
-      "from": "content-type@>=1.0.4 <1.1.0",
+      "from": "content-type@~1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz"
     },
     "convert-source-map": {
       "version": "1.6.0",
-      "from": "convert-source-map@>=1.0.0 <2.0.0",
+      "from": "convert-source-map@1.X",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
       "dev": true
     },
@@ -882,57 +882,57 @@
     },
     "cookiejar": {
       "version": "2.1.2",
-      "from": "cookiejar@>=2.0.6 <3.0.0",
+      "from": "cookiejar@^2.0.6",
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz"
     },
     "copy-descriptor": {
       "version": "0.1.1",
-      "from": "copy-descriptor@>=0.1.0 <0.2.0",
+      "from": "copy-descriptor@^0.1.0",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
-      "from": "core-util-is@>=1.0.0 <1.1.0",
+      "from": "core-util-is@~1.0.0",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
     "create-error-class": {
       "version": "3.0.2",
-      "from": "create-error-class@>=3.0.0 <4.0.0",
+      "from": "create-error-class@^3.0.0",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "dev": true
     },
     "create-frame": {
       "version": "0.1.4",
-      "from": "create-frame@>=0.1.2 <0.2.0",
+      "from": "create-frame@^0.1.2",
       "resolved": "https://registry.npmjs.org/create-frame/-/create-frame-0.1.4.tgz"
     },
     "cross-spawn": {
       "version": "6.0.5",
-      "from": "cross-spawn@>=6.0.0 <7.0.0",
+      "from": "cross-spawn@^6.0.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "dependencies": {
         "semver": {
           "version": "5.6.0",
-          "from": "semver@>=5.5.0 <6.0.0",
+          "from": "semver@^5.5.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz"
         }
       }
     },
     "cryptiles": {
       "version": "2.0.5",
-      "from": "cryptiles@>=2.0.0 <3.0.0",
+      "from": "cryptiles@2.x.x",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
     },
     "crypto-random-string": {
       "version": "1.0.0",
-      "from": "crypto-random-string@>=1.0.0 <2.0.0",
+      "from": "crypto-random-string@^1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "dev": true
     },
     "css": {
       "version": "2.2.4",
-      "from": "css@>=2.0.0 <3.0.0",
+      "from": "css@2.X",
       "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
       "dev": true
     },
@@ -943,53 +943,53 @@
     },
     "cwd": {
       "version": "0.9.1",
-      "from": "cwd@>=0.9.1 <0.10.0",
+      "from": "cwd@^0.9.1",
       "resolved": "https://registry.npmjs.org/cwd/-/cwd-0.9.1.tgz"
     },
     "d": {
       "version": "1.0.0",
-      "from": "d@>=1.0.0 <2.0.0",
+      "from": "d@1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz"
     },
     "dashdash": {
       "version": "1.14.1",
-      "from": "dashdash@>=1.12.0 <2.0.0",
+      "from": "dashdash@^1.12.0",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "from": "assert-plus@^1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "data-uri-to-buffer": {
       "version": "2.0.0",
-      "from": "data-uri-to-buffer@>=2.0.0 <3.0.0",
+      "from": "data-uri-to-buffer@2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.0.tgz",
       "dependencies": {
         "@types/node": {
           "version": "8.10.40",
-          "from": "@types/node@>=8.0.7 <9.0.0",
+          "from": "@types/node@^8.0.7",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.40.tgz"
         }
       }
     },
     "date.js": {
       "version": "0.3.3",
-      "from": "date.js@>=0.3.1 <0.4.0",
+      "from": "date.js@^0.3.1",
       "resolved": "https://registry.npmjs.org/date.js/-/date.js-0.3.3.tgz",
       "dependencies": {
         "debug": {
           "version": "3.1.0",
-          "from": "debug@>=3.1.0 <3.2.0",
+          "from": "debug@~3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz"
         }
       }
     },
     "dateformat": {
       "version": "2.2.0",
-      "from": "dateformat@>=2.0.0 <3.0.0",
+      "from": "dateformat@^2.0.0",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
       "dev": true
     },
@@ -1000,25 +1000,25 @@
     },
     "debug-fabulous": {
       "version": "1.1.0",
-      "from": "debug-fabulous@>=1.0.0 <2.0.0",
+      "from": "debug-fabulous@1.X",
       "resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-1.1.0.tgz",
       "dev": true,
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "from": "debug@>=3.0.0 <4.0.0",
+          "from": "debug@3.X",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "dev": true
         },
         "ms": {
           "version": "2.1.1",
-          "from": "ms@>=2.1.1 <3.0.0",
+          "from": "ms@^2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "from": "object-assign@>=4.0.0 <5.0.0",
+          "from": "object-assign@4.X",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "dev": true
         }
@@ -1026,97 +1026,97 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "from": "decamelize@>=1.1.1 <2.0.0",
+      "from": "decamelize@^1.1.1",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
     },
     "decode-uri-component": {
       "version": "0.2.0",
-      "from": "decode-uri-component@>=0.2.0 <0.3.0",
+      "from": "decode-uri-component@^0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "dev": true
     },
     "deep-eql": {
       "version": "3.0.1",
-      "from": "deep-eql@>=3.0.1 <4.0.0",
+      "from": "deep-eql@^3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
       "dev": true
     },
     "deep-extend": {
       "version": "0.6.0",
-      "from": "deep-extend@>=0.6.0 <0.7.0",
+      "from": "deep-extend@^0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
-      "from": "deep-is@>=0.1.3 <0.2.0",
+      "from": "deep-is@~0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
     },
     "default-compare": {
       "version": "1.0.0",
-      "from": "default-compare@>=1.0.0 <2.0.0",
+      "from": "default-compare@^1.0.0",
       "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
       "dependencies": {
         "kind-of": {
           "version": "5.1.0",
-          "from": "kind-of@>=5.0.2 <6.0.0",
+          "from": "kind-of@^5.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz"
         }
       }
     },
     "defaults": {
       "version": "1.0.3",
-      "from": "defaults@>=1.0.0 <2.0.0",
+      "from": "defaults@^1.0.0",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "dev": true
     },
     "define-property": {
       "version": "0.2.5",
-      "from": "define-property@>=0.2.5 <0.3.0",
+      "from": "define-property@^0.2.5",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz"
     },
     "degenerator": {
       "version": "1.0.4",
-      "from": "degenerator@>=1.0.4 <2.0.0",
+      "from": "degenerator@^1.0.4",
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
       "dependencies": {
         "esprima": {
           "version": "3.1.3",
-          "from": "esprima@>=3.0.0 <4.0.0",
+          "from": "esprima@3.x.x",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
         }
       }
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "from": "delayed-stream@>=1.0.0 <1.1.0",
+      "from": "delayed-stream@~1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
     },
     "depd": {
       "version": "1.1.2",
-      "from": "depd@>=1.1.2 <1.2.0",
+      "from": "depd@~1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
     },
     "deprecated": {
       "version": "0.0.1",
-      "from": "deprecated@>=0.0.1 <0.0.2",
+      "from": "deprecated@^0.0.1",
       "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
       "dev": true
     },
     "destroy": {
       "version": "1.0.4",
-      "from": "destroy@>=1.0.4 <1.1.0",
+      "from": "destroy@~1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
     },
     "detect-file": {
       "version": "1.0.0",
-      "from": "detect-file@>=1.0.0 <2.0.0",
+      "from": "detect-file@^1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
       "dev": true
     },
     "detect-newline": {
       "version": "2.1.0",
-      "from": "detect-newline@>=2.0.0 <3.0.0",
+      "from": "detect-newline@2.X",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
       "dev": true
     },
@@ -1128,7 +1128,7 @@
     },
     "dot-prop": {
       "version": "4.2.0",
-      "from": "dot-prop@>=4.1.0 <5.0.0",
+      "from": "dot-prop@^4.1.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "dev": true
     },
@@ -1140,7 +1140,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "from": "readable-stream@>=1.1.9 <1.2.0",
+          "from": "readable-stream@~1.1.9",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "dev": true
         }
@@ -1148,43 +1148,43 @@
     },
     "duplexer3": {
       "version": "0.1.4",
-      "from": "duplexer3@>=0.1.4 <0.2.0",
+      "from": "duplexer3@^0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "dev": true
     },
     "duplexify": {
       "version": "3.7.1",
-      "from": "duplexify@>=3.2.0 <4.0.0",
+      "from": "duplexify@^3.2.0",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "dev": true,
       "dependencies": {
         "end-of-stream": {
           "version": "1.4.1",
-          "from": "end-of-stream@>=1.0.0 <2.0.0",
+          "from": "end-of-stream@^1.0.0",
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
+          "from": "isarray@~1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "dev": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "from": "process-nextick-args@>=2.0.0 <2.1.0",
+          "from": "process-nextick-args@~2.0.0",
           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
           "dev": true
         },
         "readable-stream": {
           "version": "2.3.6",
-          "from": "readable-stream@>=2.0.0 <3.0.0",
+          "from": "readable-stream@^2.0.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",
-          "from": "string_decoder@>=1.1.1 <1.2.0",
+          "from": "string_decoder@~1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "dev": true
         }
@@ -1192,7 +1192,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+      "from": "ecc-jsbn@~0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz"
     },
     "ecdsa-sig-formatter": {
@@ -1212,23 +1212,23 @@
     },
     "encodeurl": {
       "version": "1.0.2",
-      "from": "encodeurl@>=1.0.2 <1.1.0",
+      "from": "encodeurl@~1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz"
     },
     "encoding": {
       "version": "0.1.12",
-      "from": "encoding@>=0.1.11 <0.2.0",
+      "from": "encoding@^0.1.11",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz"
     },
     "end-of-stream": {
       "version": "0.1.5",
-      "from": "end-of-stream@>=0.1.5 <0.2.0",
+      "from": "end-of-stream@~0.1.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
       "dev": true,
       "dependencies": {
         "once": {
           "version": "1.3.3",
-          "from": "once@>=1.3.0 <1.4.0",
+          "from": "once@~1.3.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "dev": true
         }
@@ -1236,136 +1236,136 @@
     },
     "ent": {
       "version": "2.2.0",
-      "from": "ent@>=2.2.0 <3.0.0",
+      "from": "ent@^2.2.0",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz"
     },
     "error-ex": {
       "version": "1.3.2",
-      "from": "error-ex@>=1.2.0 <2.0.0",
+      "from": "error-ex@^1.2.0",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz"
     },
     "es5-ext": {
       "version": "0.10.48",
-      "from": "es5-ext@>=0.10.45 <0.11.0",
+      "from": "es5-ext@^0.10.45",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.48.tgz"
     },
     "es6-iterator": {
       "version": "2.0.3",
-      "from": "es6-iterator@>=2.0.3 <2.1.0",
+      "from": "es6-iterator@~2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz"
     },
     "es6-promise": {
       "version": "4.2.6",
-      "from": "es6-promise@>=4.0.3 <5.0.0",
+      "from": "es6-promise@^4.0.3",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz"
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "from": "es6-promisify@>=5.0.0 <6.0.0",
+      "from": "es6-promisify@^5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz"
     },
     "es6-symbol": {
       "version": "3.1.1",
-      "from": "es6-symbol@>=3.1.1 <3.2.0",
+      "from": "es6-symbol@~3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
     },
     "es6-weak-map": {
       "version": "2.0.2",
-      "from": "es6-weak-map@>=2.0.2 <3.0.0",
+      "from": "es6-weak-map@^2.0.2",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz"
     },
     "escape-html": {
       "version": "1.0.3",
-      "from": "escape-html@>=1.0.3 <1.1.0",
+      "from": "escape-html@~1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+      "from": "escape-string-regexp@^1.0.2",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
     },
     "escodegen": {
       "version": "1.11.1",
-      "from": "escodegen@>=1.0.0 <2.0.0",
+      "from": "escodegen@1.x.x",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
       "dependencies": {
         "esprima": {
           "version": "3.1.3",
-          "from": "esprima@>=3.1.3 <4.0.0",
+          "from": "esprima@^3.1.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
         }
       }
     },
     "esprima": {
       "version": "4.0.1",
-      "from": "esprima@>=4.0.0 <5.0.0",
+      "from": "esprima@^4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz"
     },
     "estraverse": {
       "version": "4.2.0",
-      "from": "estraverse@>=4.2.0 <5.0.0",
+      "from": "estraverse@^4.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
     },
     "esutils": {
       "version": "2.0.2",
-      "from": "esutils@>=2.0.2 <3.0.0",
+      "from": "esutils@^2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
     },
     "etag": {
       "version": "1.8.1",
-      "from": "etag@>=1.8.1 <1.9.0",
+      "from": "etag@~1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
     },
     "event-emitter": {
       "version": "0.3.5",
-      "from": "event-emitter@>=0.3.5 <0.4.0",
+      "from": "event-emitter@^0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
     },
     "execa": {
       "version": "0.10.0",
-      "from": "execa@>=0.10.0 <0.11.0",
+      "from": "execa@^0.10.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz"
     },
     "expand-brackets": {
       "version": "0.1.5",
-      "from": "expand-brackets@>=0.1.4 <0.2.0",
+      "from": "expand-brackets@^0.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
     },
     "expand-range": {
       "version": "1.8.2",
-      "from": "expand-range@>=1.8.1 <2.0.0",
+      "from": "expand-range@^1.8.1",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
     },
     "expand-tilde": {
       "version": "1.2.2",
-      "from": "expand-tilde@>=1.2.2 <2.0.0",
+      "from": "expand-tilde@^1.2.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz"
     },
     "express": {
       "version": "4.16.4",
-      "from": "express@>=4.0.34 <5.0.0",
+      "from": "express@^4.0.34",
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
       "dependencies": {
         "statuses": {
           "version": "1.4.0",
-          "from": "statuses@>=1.4.0 <1.5.0",
+          "from": "statuses@~1.4.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz"
         }
       }
     },
     "extend": {
       "version": "2.0.2",
-      "from": "extend@>=2.0.1 <2.1.0",
+      "from": "extend@~2.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.2.tgz"
     },
     "extend-shallow": {
       "version": "2.0.1",
-      "from": "extend-shallow@>=2.0.1 <3.0.0",
+      "from": "extend-shallow@^2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
     },
     "extglob": {
       "version": "0.3.2",
-      "from": "extglob@>=0.3.1 <0.4.0",
+      "from": "extglob@^0.3.1",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
     },
     "extsprintf": {
@@ -1375,72 +1375,72 @@
     },
     "fancy-log": {
       "version": "1.3.3",
-      "from": "fancy-log@>=1.1.0 <2.0.0",
+      "from": "fancy-log@^1.1.0",
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
       "dev": true
     },
     "fast-deep-equal": {
       "version": "2.0.1",
-      "from": "fast-deep-equal@>=2.0.1 <3.0.0",
+      "from": "fast-deep-equal@^2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz"
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "from": "fast-json-stable-stringify@>=2.0.0 <3.0.0",
+      "from": "fast-json-stable-stringify@^2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "from": "fast-levenshtein@>=2.0.4 <2.1.0",
+      "from": "fast-levenshtein@~2.0.4",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
     },
     "fetch-ponyfill": {
       "version": "4.1.0",
-      "from": "fetch-ponyfill@>=4.0.0 <5.0.0",
+      "from": "fetch-ponyfill@^4.0.0",
       "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-4.1.0.tgz"
     },
     "file-contents": {
       "version": "0.2.4",
-      "from": "file-contents@>=0.2.4 <0.3.0",
+      "from": "file-contents@^0.2.4",
       "resolved": "https://registry.npmjs.org/file-contents/-/file-contents-0.2.4.tgz",
       "dependencies": {
         "lazy-cache": {
           "version": "0.2.7",
-          "from": "lazy-cache@>=0.2.3 <0.3.0",
+          "from": "lazy-cache@^0.2.3",
           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
         }
       }
     },
     "file-name": {
       "version": "0.1.0",
-      "from": "file-name@>=0.1.0 <0.2.0",
+      "from": "file-name@^0.1.0",
       "resolved": "https://registry.npmjs.org/file-name/-/file-name-0.1.0.tgz"
     },
     "file-stat": {
       "version": "0.1.3",
-      "from": "file-stat@>=0.1.0 <0.2.0",
+      "from": "file-stat@^0.1.0",
       "resolved": "https://registry.npmjs.org/file-stat/-/file-stat-0.1.3.tgz",
       "dependencies": {
         "lazy-cache": {
           "version": "0.2.7",
-          "from": "lazy-cache@>=0.2.3 <0.3.0",
+          "from": "lazy-cache@^0.2.3",
           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
         }
       }
     },
     "file-uri-to-path": {
       "version": "1.0.0",
-      "from": "file-uri-to-path@>=1.0.0 <2.0.0",
+      "from": "file-uri-to-path@1",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz"
     },
     "filename-regex": {
       "version": "2.0.1",
-      "from": "filename-regex@>=2.0.0 <3.0.0",
+      "from": "filename-regex@^2.0.0",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz"
     },
     "fill-range": {
       "version": "2.2.4",
-      "from": "fill-range@>=2.1.0 <3.0.0",
+      "from": "fill-range@^2.1.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
       "dependencies": {
         "isarray": {
@@ -1450,7 +1450,7 @@
         },
         "isobject": {
           "version": "2.1.0",
-          "from": "isobject@>=2.0.0 <3.0.0",
+          "from": "isobject@^2.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
         }
       }
@@ -1462,53 +1462,53 @@
       "dependencies": {
         "statuses": {
           "version": "1.4.0",
-          "from": "statuses@>=1.4.0 <1.5.0",
+          "from": "statuses@~1.4.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz"
         }
       }
     },
     "find-file-up": {
       "version": "0.1.3",
-      "from": "find-file-up@>=0.1.2 <0.2.0",
+      "from": "find-file-up@^0.1.2",
       "resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz"
     },
     "find-index": {
       "version": "0.1.1",
-      "from": "find-index@>=0.1.1 <0.2.0",
+      "from": "find-index@^0.1.1",
       "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
       "dev": true
     },
     "find-pkg": {
       "version": "0.1.2",
-      "from": "find-pkg@>=0.1.2 <0.2.0",
+      "from": "find-pkg@^0.1.2",
       "resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz"
     },
     "find-up": {
       "version": "2.1.0",
-      "from": "find-up@>=2.0.0 <3.0.0",
+      "from": "find-up@^2.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz"
     },
     "findup-sync": {
       "version": "2.0.0",
-      "from": "findup-sync@>=2.0.0 <3.0.0",
+      "from": "findup-sync@^2.0.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
       "dev": true,
       "dependencies": {
         "arr-diff": {
           "version": "4.0.0",
-          "from": "arr-diff@>=4.0.0 <5.0.0",
+          "from": "arr-diff@^4.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
           "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
-          "from": "array-unique@>=0.3.2 <0.4.0",
+          "from": "array-unique@^0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
           "dev": true
         },
         "braces": {
           "version": "2.3.2",
-          "from": "braces@>=2.3.1 <3.0.0",
+          "from": "braces@^2.3.1",
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "dev": true,
           "dependencies": {
@@ -1522,13 +1522,13 @@
         },
         "define-property": {
           "version": "2.0.2",
-          "from": "define-property@>=2.0.2 <3.0.0",
+          "from": "define-property@^2.0.2",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
           "dev": true
         },
         "expand-brackets": {
           "version": "2.1.4",
-          "from": "expand-brackets@>=2.1.4 <3.0.0",
+          "from": "expand-brackets@^2.1.4",
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "dev": true,
           "dependencies": {
@@ -1580,7 +1580,7 @@
             },
             "kind-of": {
               "version": "5.1.0",
-              "from": "kind-of@>=5.0.0 <6.0.0",
+              "from": "kind-of@^5.0.0",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "dev": true
             }
@@ -1588,19 +1588,19 @@
         },
         "expand-tilde": {
           "version": "2.0.2",
-          "from": "expand-tilde@>=2.0.0 <3.0.0",
+          "from": "expand-tilde@^2.0.0",
           "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
           "dev": true
         },
         "extend-shallow": {
           "version": "3.0.2",
-          "from": "extend-shallow@>=3.0.2 <4.0.0",
+          "from": "extend-shallow@^3.0.2",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "dev": true,
           "dependencies": {
             "is-extendable": {
               "version": "1.0.1",
-              "from": "is-extendable@>=1.0.1 <2.0.0",
+              "from": "is-extendable@^1.0.1",
               "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
               "dev": true
             }
@@ -1608,13 +1608,13 @@
         },
         "extglob": {
           "version": "2.0.4",
-          "from": "extglob@>=2.0.4 <3.0.0",
+          "from": "extglob@^2.0.4",
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "dev": true,
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "from": "define-property@>=1.0.0 <2.0.0",
+              "from": "define-property@^1.0.0",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "dev": true
             },
@@ -1628,7 +1628,7 @@
         },
         "fill-range": {
           "version": "4.0.0",
-          "from": "fill-range@>=4.0.0 <5.0.0",
+          "from": "fill-range@^4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "dev": true,
           "dependencies": {
@@ -1642,49 +1642,49 @@
         },
         "global-modules": {
           "version": "1.0.0",
-          "from": "global-modules@>=1.0.0 <2.0.0",
+          "from": "global-modules@^1.0.0",
           "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
           "dev": true
         },
         "global-prefix": {
           "version": "1.0.2",
-          "from": "global-prefix@>=1.0.1 <2.0.0",
+          "from": "global-prefix@^1.0.1",
           "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
           "dev": true
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "from": "is-accessor-descriptor@>=1.0.0 <2.0.0",
+          "from": "is-accessor-descriptor@^1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "dev": true
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "from": "is-data-descriptor@>=1.0.0 <2.0.0",
+          "from": "is-data-descriptor@^1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "dev": true
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "from": "is-descriptor@>=1.0.2 <2.0.0",
+          "from": "is-descriptor@^1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "dev": true
         },
         "is-extglob": {
           "version": "2.1.1",
-          "from": "is-extglob@>=2.1.0 <3.0.0",
+          "from": "is-extglob@^2.1.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "dev": true
         },
         "is-glob": {
           "version": "3.1.0",
-          "from": "is-glob@>=3.1.0 <4.0.0",
+          "from": "is-glob@^3.1.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "dev": true
         },
         "is-number": {
           "version": "3.0.0",
-          "from": "is-number@>=3.0.0 <4.0.0",
+          "from": "is-number@^3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "dev": true,
           "dependencies": {
@@ -1698,31 +1698,31 @@
         },
         "is-windows": {
           "version": "1.0.2",
-          "from": "is-windows@>=1.0.1 <2.0.0",
+          "from": "is-windows@^1.0.1",
           "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
           "dev": true
         },
         "isobject": {
           "version": "3.0.1",
-          "from": "isobject@>=3.0.1 <4.0.0",
+          "from": "isobject@^3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "dev": true
         },
         "kind-of": {
           "version": "6.0.2",
-          "from": "kind-of@>=6.0.2 <7.0.0",
+          "from": "kind-of@^6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "dev": true
         },
         "micromatch": {
           "version": "3.1.10",
-          "from": "micromatch@>=3.0.4 <4.0.0",
+          "from": "micromatch@^3.0.4",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "dev": true
         },
         "resolve-dir": {
           "version": "1.0.1",
-          "from": "resolve-dir@>=1.0.1 <2.0.0",
+          "from": "resolve-dir@^1.0.1",
           "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
           "dev": true
         }
@@ -1730,13 +1730,13 @@
     },
     "fined": {
       "version": "1.1.1",
-      "from": "fined@>=1.0.1 <2.0.0",
+      "from": "fined@^1.0.1",
       "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.1.tgz",
       "dev": true,
       "dependencies": {
         "expand-tilde": {
           "version": "2.0.2",
-          "from": "expand-tilde@>=2.0.2 <3.0.0",
+          "from": "expand-tilde@^2.0.2",
           "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
           "dev": true
         }
@@ -1744,13 +1744,13 @@
     },
     "first-chunk-stream": {
       "version": "1.0.0",
-      "from": "first-chunk-stream@>=1.0.0 <2.0.0",
+      "from": "first-chunk-stream@^1.0.0",
       "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
       "dev": true
     },
     "flagged-respawn": {
       "version": "1.0.1",
-      "from": "flagged-respawn@>=1.0.0 <2.0.0",
+      "from": "flagged-respawn@^1.0.0",
       "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
       "dev": true
     },
@@ -1761,22 +1761,22 @@
       "dependencies": {
         "mime-db": {
           "version": "1.12.0",
-          "from": "mime-db@>=1.12.0 <1.13.0",
+          "from": "mime-db@~1.12.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
         },
         "mime-types": {
           "version": "2.0.14",
-          "from": "mime-types@>=2.0.1 <2.1.0",
+          "from": "mime-types@~2.0.1",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz"
         },
         "qs": {
           "version": "3.1.0",
-          "from": "qs@>=3.1.0 <3.2.0",
+          "from": "qs@~3.1.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz"
         },
         "request": {
           "version": "2.58.0",
-          "from": "request@>=2.58.0 <2.59.0",
+          "from": "request@~2.58.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.58.0.tgz"
         }
       }
@@ -1788,44 +1788,44 @@
     },
     "for-in": {
       "version": "0.1.8",
-      "from": "for-in@>=0.1.5 <0.2.0",
+      "from": "for-in@^0.1.5",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz"
     },
     "for-own": {
       "version": "0.1.5",
-      "from": "for-own@>=0.1.4 <0.2.0",
+      "from": "for-own@^0.1.4",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "dependencies": {
         "for-in": {
           "version": "1.0.2",
-          "from": "for-in@>=1.0.1 <2.0.0",
+          "from": "for-in@^1.0.1",
           "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
         }
       }
     },
     "forever-agent": {
       "version": "0.6.1",
-      "from": "forever-agent@>=0.6.0 <0.7.0",
+      "from": "forever-agent@~0.6.0",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
     },
     "form-data": {
       "version": "1.0.1",
-      "from": "form-data@>=1.0.0-rc1 <1.1.0",
+      "from": "form-data@~1.0.0-rc1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz"
     },
     "formidable": {
       "version": "1.2.1",
-      "from": "formidable@>=1.0.17 <2.0.0",
+      "from": "formidable@^1.0.17",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz"
     },
     "forwarded": {
       "version": "0.1.2",
-      "from": "forwarded@>=0.1.2 <0.2.0",
+      "from": "forwarded@~0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz"
     },
     "fragment-cache": {
       "version": "0.2.1",
-      "from": "fragment-cache@>=0.2.1 <0.3.0",
+      "from": "fragment-cache@^0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "dev": true
     },
@@ -1835,9 +1835,9 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
     },
     "front-sdk": {
-      "version": "0.3.6",
-      "from": "front-sdk@>=0.3.1 <0.4.0",
-      "resolved": "https://registry.npmjs.org/front-sdk/-/front-sdk-0.3.6.tgz",
+      "version": "0.6.0",
+      "from": "front-sdk@0.6.0",
+      "resolved": "https://registry.npmjs.org/front-sdk/-/front-sdk-0.6.0.tgz",
       "dependencies": {
         "@types/body-parser": {
           "version": "1.17.0",
@@ -1848,136 +1848,136 @@
     },
     "fs-exists-sync": {
       "version": "0.1.0",
-      "from": "fs-exists-sync@>=0.1.0 <0.2.0",
+      "from": "fs-exists-sync@^0.1.0",
       "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz"
     },
     "fs-extra": {
       "version": "3.0.1",
-      "from": "fs-extra@>=3.0.0 <4.0.0",
+      "from": "fs-extra@^3.0.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
       "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "from": "fs.realpath@>=1.0.0 <2.0.0",
+      "from": "fs.realpath@^1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
     },
     "ftp": {
       "version": "0.3.10",
-      "from": "ftp@>=0.3.10 <0.4.0",
+      "from": "ftp@~0.3.10",
       "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "from": "readable-stream@>=1.1.0 <1.2.0",
+          "from": "readable-stream@1.1.x",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
         }
       }
     },
     "gaze": {
       "version": "0.5.2",
-      "from": "gaze@>=0.5.1 <0.6.0",
+      "from": "gaze@^0.5.1",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
       "dev": true
     },
     "generate-function": {
       "version": "2.3.1",
-      "from": "generate-function@>=2.0.0 <3.0.0",
+      "from": "generate-function@^2.0.0",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz"
     },
     "generate-object-property": {
       "version": "1.2.0",
-      "from": "generate-object-property@>=1.1.0 <2.0.0",
+      "from": "generate-object-property@^1.1.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
     },
     "get-caller-file": {
       "version": "1.0.3",
-      "from": "get-caller-file@>=1.0.1 <2.0.0",
+      "from": "get-caller-file@^1.0.1",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz"
     },
     "get-func-name": {
       "version": "2.0.0",
-      "from": "get-func-name@>=2.0.0 <3.0.0",
+      "from": "get-func-name@^2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "dev": true
     },
     "get-object": {
       "version": "0.2.0",
-      "from": "get-object@>=0.2.0 <0.3.0",
+      "from": "get-object@^0.2.0",
       "resolved": "https://registry.npmjs.org/get-object/-/get-object-0.2.0.tgz"
     },
     "get-stdin": {
       "version": "4.0.1",
-      "from": "get-stdin@>=4.0.1 <5.0.0",
+      "from": "get-stdin@^4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
     },
     "get-stream": {
       "version": "3.0.0",
-      "from": "get-stream@>=3.0.0 <4.0.0",
+      "from": "get-stream@^3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz"
     },
     "get-uri": {
       "version": "2.0.3",
-      "from": "get-uri@>=2.0.0 <3.0.0",
+      "from": "get-uri@^2.0.0",
       "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.3.tgz",
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "from": "debug@>=4.0.0 <5.0.0",
+          "from": "debug@4",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz"
         },
         "extend": {
           "version": "3.0.2",
-          "from": "extend@>=3.0.2 <3.1.0",
+          "from": "extend@~3.0.2",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
         },
         "ms": {
           "version": "2.1.1",
-          "from": "ms@>=2.1.1 <3.0.0",
+          "from": "ms@^2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz"
         },
         "readable-stream": {
           "version": "3.1.1",
-          "from": "readable-stream@>=3.0.0 <4.0.0",
+          "from": "readable-stream@3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz"
         },
         "string_decoder": {
           "version": "1.2.0",
-          "from": "string_decoder@>=1.1.1 <2.0.0",
+          "from": "string_decoder@^1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz"
         }
       }
     },
     "get-value": {
       "version": "2.0.6",
-      "from": "get-value@>=2.0.6 <3.0.0",
+      "from": "get-value@^2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz"
     },
     "getpass": {
       "version": "0.1.7",
-      "from": "getpass@>=0.1.1 <0.2.0",
+      "from": "getpass@^0.1.1",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "from": "assert-plus@^1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "git-config-path": {
       "version": "1.0.1",
-      "from": "git-config-path@>=1.0.1 <2.0.0",
+      "from": "git-config-path@^1.0.1",
       "resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz"
     },
     "git-repo-name": {
       "version": "0.6.0",
-      "from": "git-repo-name@>=0.6.0 <0.7.0",
+      "from": "git-repo-name@^0.6.0",
       "resolved": "https://registry.npmjs.org/git-repo-name/-/git-repo-name-0.6.0.tgz",
       "dependencies": {
         "lazy-cache": {
           "version": "1.0.4",
-          "from": "lazy-cache@>=1.0.4 <2.0.0",
+          "from": "lazy-cache@^1.0.4",
           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
         }
       }
@@ -1989,62 +1989,62 @@
     },
     "github-webhook-handler": {
       "version": "0.6.0",
-      "from": "github-webhook-handler@>=0.6.0 <0.7.0",
+      "from": "github-webhook-handler@^0.6.0",
       "resolved": "https://registry.npmjs.org/github-webhook-handler/-/github-webhook-handler-0.6.0.tgz",
       "dependencies": {
         "bl": {
           "version": "1.1.2",
-          "from": "bl@>=1.1.2 <1.2.0",
+          "from": "bl@~1.1.2",
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz"
         },
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
+          "from": "isarray@~1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.0.6",
-          "from": "readable-stream@>=2.0.5 <2.1.0",
+          "from": "readable-stream@~2.0.5",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         }
       }
     },
     "glob": {
       "version": "7.1.3",
-      "from": "glob@>=7.0.5 <8.0.0",
+      "from": "glob@^7.0.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz"
     },
     "glob-base": {
       "version": "0.3.0",
-      "from": "glob-base@>=0.3.0 <0.4.0",
+      "from": "glob-base@^0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
     },
     "glob-parent": {
       "version": "2.0.0",
-      "from": "glob-parent@>=2.0.0 <3.0.0",
+      "from": "glob-parent@^2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
     },
     "glob-stream": {
       "version": "3.1.18",
-      "from": "glob-stream@>=3.1.5 <4.0.0",
+      "from": "glob-stream@^3.1.5",
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
       "dev": true,
       "dependencies": {
         "glob": {
           "version": "4.5.3",
-          "from": "glob@>=4.3.1 <5.0.0",
+          "from": "glob@^4.3.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "dev": true
         },
         "minimatch": {
           "version": "2.0.10",
-          "from": "minimatch@>=2.0.1 <3.0.0",
+          "from": "minimatch@^2.0.1",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "dev": true
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.1 <0.7.0",
+          "from": "through2@^0.6.1",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dev": true
         }
@@ -2052,71 +2052,71 @@
     },
     "glob-watcher": {
       "version": "0.0.6",
-      "from": "glob-watcher@>=0.0.6 <0.0.7",
+      "from": "glob-watcher@^0.0.6",
       "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
       "dev": true
     },
     "glob2base": {
       "version": "0.0.12",
-      "from": "glob2base@>=0.0.12 <0.0.13",
+      "from": "glob2base@^0.0.12",
       "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
       "dev": true
     },
     "global-dirs": {
       "version": "0.1.1",
-      "from": "global-dirs@>=0.1.0 <0.2.0",
+      "from": "global-dirs@^0.1.0",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
       "dev": true
     },
     "global-modules": {
       "version": "0.2.3",
-      "from": "global-modules@>=0.2.3 <0.3.0",
+      "from": "global-modules@^0.2.3",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz"
     },
     "global-prefix": {
       "version": "0.1.5",
-      "from": "global-prefix@>=0.1.4 <0.2.0",
+      "from": "global-prefix@^0.1.4",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz"
     },
     "globule": {
       "version": "0.1.0",
-      "from": "globule@>=0.1.0 <0.2.0",
+      "from": "globule@~0.1.0",
       "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
       "dev": true,
       "dependencies": {
         "glob": {
           "version": "3.1.21",
-          "from": "glob@>=3.1.21 <3.2.0",
+          "from": "glob@~3.1.21",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dev": true
         },
         "graceful-fs": {
           "version": "1.2.3",
-          "from": "graceful-fs@>=1.2.0 <1.3.0",
+          "from": "graceful-fs@~1.2.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
           "dev": true
         },
         "inherits": {
           "version": "1.0.2",
-          "from": "inherits@>=1.0.0 <2.0.0",
+          "from": "inherits@1",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
           "dev": true
         },
         "lodash": {
           "version": "1.0.2",
-          "from": "lodash@>=1.0.1 <1.1.0",
+          "from": "lodash@~1.0.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
           "dev": true
         },
         "lru-cache": {
           "version": "2.7.3",
-          "from": "lru-cache@>=2.0.0 <3.0.0",
+          "from": "lru-cache@2",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
           "dev": true
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@>=0.2.11 <0.3.0",
+          "from": "minimatch@~0.2.11",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dev": true
         }
@@ -2124,19 +2124,19 @@
     },
     "glogg": {
       "version": "1.0.2",
-      "from": "glogg@>=1.0.0 <2.0.0",
+      "from": "glogg@^1.0.0",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
       "dev": true
     },
     "got": {
       "version": "6.7.1",
-      "from": "got@>=6.7.1 <7.0.0",
+      "from": "got@^6.7.1",
       "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "dev": true
     },
     "graceful-fs": {
       "version": "4.1.15",
-      "from": "graceful-fs@>=4.1.11 <5.0.0",
+      "from": "graceful-fs@^4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz"
     },
     "growl": {
@@ -2147,19 +2147,19 @@
     },
     "gulp": {
       "version": "3.9.1",
-      "from": "gulp@>=3.9.1 <4.0.0",
+      "from": "gulp@^3.9.1",
       "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
       "dev": true,
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.1.0 <2.0.0",
+          "from": "minimist@^1.1.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "dev": true
         },
         "semver": {
           "version": "4.3.6",
-          "from": "semver@>=4.1.0 <5.0.0",
+          "from": "semver@^4.1.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "dev": true
         }
@@ -2167,43 +2167,43 @@
     },
     "gulp-sourcemaps": {
       "version": "2.6.5",
-      "from": "gulp-sourcemaps@>=2.4.1 <3.0.0",
+      "from": "gulp-sourcemaps@^2.4.1",
       "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-2.6.5.tgz",
       "dev": true
     },
     "gulp-tslint": {
       "version": "7.1.0",
-      "from": "gulp-tslint@>=7.1.0 <8.0.0",
+      "from": "gulp-tslint@^7.1.0",
       "resolved": "https://registry.npmjs.org/gulp-tslint/-/gulp-tslint-7.1.0.tgz",
       "dev": true
     },
     "gulp-typescript": {
       "version": "3.2.4",
-      "from": "gulp-typescript@>=3.1.5 <4.0.0",
+      "from": "gulp-typescript@^3.1.5",
       "resolved": "https://registry.npmjs.org/gulp-typescript/-/gulp-typescript-3.2.4.tgz",
       "dev": true,
       "dependencies": {
         "extend": {
           "version": "3.0.2",
-          "from": "extend@>=3.0.0 <4.0.0",
+          "from": "extend@^3.0.0",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "dev": true
         },
         "glob": {
           "version": "5.0.15",
-          "from": "glob@>=5.0.3 <6.0.0",
+          "from": "glob@^5.0.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "dev": true
         },
         "glob-parent": {
           "version": "3.1.0",
-          "from": "glob-parent@>=3.0.0 <4.0.0",
+          "from": "glob-parent@^3.0.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "dev": true
         },
         "glob-stream": {
           "version": "5.3.5",
-          "from": "glob-stream@>=5.3.2 <6.0.0",
+          "from": "glob-stream@^5.3.2",
           "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
           "dev": true,
           "dependencies": {
@@ -2227,7 +2227,7 @@
             },
             "through2": {
               "version": "0.6.5",
-              "from": "through2@>=0.6.0 <0.7.0",
+              "from": "through2@^0.6.0",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "dev": true
             }
@@ -2241,73 +2241,73 @@
         },
         "is-extglob": {
           "version": "2.1.1",
-          "from": "is-extglob@>=2.1.0 <3.0.0",
+          "from": "is-extglob@^2.1.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "dev": true
         },
         "is-glob": {
           "version": "3.1.0",
-          "from": "is-glob@>=3.1.0 <4.0.0",
+          "from": "is-glob@^3.1.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
+          "from": "isarray@~1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "from": "object-assign@>=4.0.0 <5.0.0",
+          "from": "object-assign@^4.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "dev": true
         },
         "ordered-read-streams": {
           "version": "0.3.0",
-          "from": "ordered-read-streams@>=0.3.0 <0.4.0",
+          "from": "ordered-read-streams@^0.3.0",
           "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
           "dev": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "from": "process-nextick-args@>=2.0.0 <2.1.0",
+          "from": "process-nextick-args@~2.0.0",
           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
           "dev": true
         },
         "readable-stream": {
           "version": "2.3.6",
-          "from": "readable-stream@>=2.0.4 <3.0.0",
+          "from": "readable-stream@^2.0.4",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
-          "from": "source-map@>=0.5.3 <0.6.0",
+          "from": "source-map@~0.5.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",
-          "from": "string_decoder@>=1.1.1 <1.2.0",
+          "from": "string_decoder@~1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "dev": true
         },
         "strip-bom": {
           "version": "2.0.0",
-          "from": "strip-bom@>=2.0.0 <3.0.0",
+          "from": "strip-bom@^2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "dev": true
         },
         "unique-stream": {
           "version": "2.3.1",
-          "from": "unique-stream@>=2.0.2 <3.0.0",
+          "from": "unique-stream@^2.0.2",
           "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
           "dev": true,
           "dependencies": {
             "through2-filter": {
               "version": "3.0.0",
-              "from": "through2-filter@>=3.0.0 <4.0.0",
+              "from": "through2-filter@^3.0.0",
               "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
               "dev": true
             }
@@ -2315,7 +2315,7 @@
         },
         "vinyl-fs": {
           "version": "2.4.4",
-          "from": "vinyl-fs@>=2.4.3 <2.5.0",
+          "from": "vinyl-fs@~2.4.3",
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
           "dev": true
         }
@@ -2323,19 +2323,19 @@
     },
     "gulp-util": {
       "version": "3.0.8",
-      "from": "gulp-util@>=3.0.8 <4.0.0",
+      "from": "gulp-util@^3.0.8",
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
       "dev": true,
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.1.0 <2.0.0",
+          "from": "minimist@^1.1.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "dev": true
         },
         "vinyl": {
           "version": "0.5.3",
-          "from": "vinyl@>=0.5.0 <0.6.0",
+          "from": "vinyl@^0.5.0",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
           "dev": true
         }
@@ -2343,68 +2343,68 @@
     },
     "gulplog": {
       "version": "1.0.0",
-      "from": "gulplog@>=1.0.0 <2.0.0",
+      "from": "gulplog@^1.0.0",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
       "dev": true
     },
     "handlebars": {
       "version": "4.1.0",
-      "from": "handlebars@>=4.0.5 <5.0.0",
+      "from": "handlebars@^4.0.5",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz"
     },
     "handlebars-helpers": {
       "version": "0.6.2",
-      "from": "handlebars-helpers@>=0.6.1 <0.7.0",
+      "from": "handlebars-helpers@^0.6.1",
       "resolved": "https://registry.npmjs.org/handlebars-helpers/-/handlebars-helpers-0.6.2.tgz"
     },
     "har-schema": {
       "version": "2.0.0",
-      "from": "har-schema@>=2.0.0 <3.0.0",
+      "from": "har-schema@^2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz"
     },
     "har-validator": {
       "version": "1.8.0",
-      "from": "har-validator@>=1.6.1 <2.0.0",
+      "from": "har-validator@^1.6.1",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
       "dependencies": {
         "bluebird": {
           "version": "2.11.0",
-          "from": "bluebird@>=2.9.30 <3.0.0",
+          "from": "bluebird@^2.9.30",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz"
         }
       }
     },
     "has-ansi": {
       "version": "2.0.0",
-      "from": "has-ansi@>=2.0.0 <3.0.0",
+      "from": "has-ansi@^2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
     },
     "has-flag": {
       "version": "3.0.0",
-      "from": "has-flag@>=3.0.0 <4.0.0",
+      "from": "has-flag@^3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz"
     },
     "has-gulplog": {
       "version": "0.1.0",
-      "from": "has-gulplog@>=0.1.0 <0.2.0",
+      "from": "has-gulplog@^0.1.0",
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "dev": true
     },
     "has-value": {
       "version": "1.0.0",
-      "from": "has-value@>=1.0.0 <2.0.0",
+      "from": "has-value@^1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "dev": true,
       "dependencies": {
         "has-values": {
           "version": "1.0.0",
-          "from": "has-values@>=1.0.0 <2.0.0",
+          "from": "has-values@^1.0.0",
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
           "dev": true
         },
         "is-number": {
           "version": "3.0.0",
-          "from": "is-number@>=3.0.0 <4.0.0",
+          "from": "is-number@^3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "dev": true,
           "dependencies": {
@@ -2418,13 +2418,13 @@
         },
         "isobject": {
           "version": "3.0.1",
-          "from": "isobject@>=3.0.0 <4.0.0",
+          "from": "isobject@^3.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "dev": true
         },
         "kind-of": {
           "version": "4.0.0",
-          "from": "kind-of@>=4.0.0 <5.0.0",
+          "from": "kind-of@^4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "dev": true
         }
@@ -2432,12 +2432,12 @@
     },
     "has-values": {
       "version": "0.1.4",
-      "from": "has-values@>=0.1.4 <0.2.0",
+      "from": "has-values@^0.1.4",
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz"
     },
     "hawk": {
       "version": "2.3.1",
-      "from": "hawk@>=2.3.0 <2.4.0",
+      "from": "hawk@~2.3.0",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz"
     },
     "he": {
@@ -2448,12 +2448,12 @@
     },
     "helper-date": {
       "version": "0.2.3",
-      "from": "helper-date@>=0.2.2 <0.3.0",
+      "from": "helper-date@^0.2.2",
       "resolved": "https://registry.npmjs.org/helper-date/-/helper-date-0.2.3.tgz"
     },
     "helper-markdown": {
       "version": "0.2.2",
-      "from": "helper-markdown@>=0.2.1 <0.3.0",
+      "from": "helper-markdown@^0.2.1",
       "resolved": "https://registry.npmjs.org/helper-markdown/-/helper-markdown-0.2.2.tgz",
       "dependencies": {
         "isarray": {
@@ -2463,19 +2463,19 @@
         },
         "isobject": {
           "version": "2.1.0",
-          "from": "isobject@>=2.0.0 <3.0.0",
+          "from": "isobject@^2.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
         }
       }
     },
     "helper-md": {
       "version": "0.2.2",
-      "from": "helper-md@>=0.2.1 <0.3.0",
+      "from": "helper-md@^0.2.1",
       "resolved": "https://registry.npmjs.org/helper-md/-/helper-md-0.2.2.tgz"
     },
     "hidepath": {
       "version": "1.0.1",
-      "from": "hidepath@>=1.0.0 <2.0.0",
+      "from": "hidepath@^1.0.0",
       "resolved": "https://registry.npmjs.org/hidepath/-/hidepath-1.0.1.tgz"
     },
     "highlight.js": {
@@ -2486,52 +2486,52 @@
     },
     "hmac": {
       "version": "1.0.1",
-      "from": "hmac@>=1.0.1 <2.0.0",
+      "from": "hmac@^1.0.1",
       "resolved": "https://registry.npmjs.org/hmac/-/hmac-1.0.1.tgz"
     },
     "hoek": {
       "version": "2.16.3",
-      "from": "hoek@>=2.0.0 <3.0.0",
+      "from": "hoek@2.x.x",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
     },
     "home-or-tmp": {
       "version": "2.0.0",
-      "from": "home-or-tmp@>=2.0.0 <3.0.0",
+      "from": "home-or-tmp@^2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz"
     },
     "homedir-polyfill": {
       "version": "1.0.3",
-      "from": "homedir-polyfill@>=1.0.0 <2.0.0",
+      "from": "homedir-polyfill@^1.0.0",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz"
     },
     "hosted-git-info": {
       "version": "2.7.1",
-      "from": "hosted-git-info@>=2.1.4 <3.0.0",
+      "from": "hosted-git-info@^2.1.4",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz"
     },
     "html-entities": {
       "version": "1.2.1",
-      "from": "html-entities@>=1.2.1 <2.0.0",
+      "from": "html-entities@^1.2.1",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz"
     },
     "html-tag": {
       "version": "0.2.1",
-      "from": "html-tag@>=0.2.1 <0.3.0",
+      "from": "html-tag@^0.2.1",
       "resolved": "https://registry.npmjs.org/html-tag/-/html-tag-0.2.1.tgz"
     },
     "http-errors": {
       "version": "1.6.3",
-      "from": "http-errors@>=1.6.3 <1.7.0",
+      "from": "http-errors@~1.6.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz"
     },
     "http-proxy-agent": {
       "version": "2.1.0",
-      "from": "http-proxy-agent@>=2.1.0 <3.0.0",
+      "from": "http-proxy-agent@^2.1.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
       "dependencies": {
         "agent-base": {
           "version": "4.2.1",
-          "from": "agent-base@>=4.0.0 <5.0.0",
+          "from": "agent-base@4",
           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz"
         },
         "debug": {
@@ -2543,24 +2543,24 @@
     },
     "http-signature": {
       "version": "0.11.0",
-      "from": "http-signature@>=0.11.0 <0.12.0",
+      "from": "http-signature@~0.11.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz"
     },
     "https-proxy-agent": {
       "version": "1.0.0",
-      "from": "https-proxy-agent@>=1.0.0 <2.0.0",
+      "from": "https-proxy-agent@^1.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
       "dependencies": {
         "extend": {
           "version": "3.0.2",
-          "from": "extend@>=3.0.0 <4.0.0",
+          "from": "extend@3",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
         }
       }
     },
     "humanize-ms": {
       "version": "1.2.1",
-      "from": "humanize-ms@>=1.2.1 <2.0.0",
+      "from": "humanize-ms@^1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz"
     },
     "iconv-lite": {
@@ -2570,23 +2570,23 @@
     },
     "import-lazy": {
       "version": "2.1.0",
-      "from": "import-lazy@>=2.1.0 <3.0.0",
+      "from": "import-lazy@^2.1.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
       "dev": true
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "from": "imurmurhash@>=0.1.4 <0.2.0",
+      "from": "imurmurhash@^0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
     },
     "index-of": {
       "version": "0.2.0",
-      "from": "index-of@>=0.2.0 <0.3.0",
+      "from": "index-of@^0.2.0",
       "resolved": "https://registry.npmjs.org/index-of/-/index-of-0.2.0.tgz"
     },
     "inflight": {
       "version": "1.0.6",
-      "from": "inflight@>=1.0.4 <2.0.0",
+      "from": "inflight@^1.0.4",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
     },
     "inherits": {
@@ -2596,28 +2596,28 @@
     },
     "ini": {
       "version": "1.3.5",
-      "from": "ini@>=1.3.4 <2.0.0",
+      "from": "ini@^1.3.4",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz"
     },
     "interpret": {
       "version": "1.2.0",
-      "from": "interpret@>=1.0.0 <2.0.0",
+      "from": "interpret@^1.0.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
       "dev": true
     },
     "invert-kv": {
       "version": "1.0.0",
-      "from": "invert-kv@>=1.0.0 <2.0.0",
+      "from": "invert-kv@^1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
     },
     "ip": {
       "version": "1.1.5",
-      "from": "ip@>=1.1.5 <2.0.0",
+      "from": "ip@^1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz"
     },
     "ip-regex": {
       "version": "2.1.0",
-      "from": "ip-regex@>=2.1.0 <3.0.0",
+      "from": "ip-regex@^2.1.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz"
     },
     "ipaddr.js": {
@@ -2627,230 +2627,230 @@
     },
     "is": {
       "version": "0.2.7",
-      "from": "is@>=0.2.6 <0.3.0",
+      "from": "is@~0.2.6",
       "resolved": "https://registry.npmjs.org/is/-/is-0.2.7.tgz"
     },
     "is-absolute": {
       "version": "0.2.6",
-      "from": "is-absolute@>=0.2.6 <0.3.0",
+      "from": "is-absolute@^0.2.6",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz"
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "from": "is-accessor-descriptor@>=0.1.6 <0.2.0",
+      "from": "is-accessor-descriptor@^0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz"
     },
     "is-admin": {
       "version": "1.0.2",
-      "from": "is-admin@>=1.0.2 <2.0.0",
+      "from": "is-admin@^1.0.2",
       "resolved": "https://registry.npmjs.org/is-admin/-/is-admin-1.0.2.tgz"
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "from": "is-arrayish@>=0.2.1 <0.3.0",
+      "from": "is-arrayish@^0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
     },
     "is-buffer": {
       "version": "1.1.6",
-      "from": "is-buffer@>=1.1.5 <2.0.0",
+      "from": "is-buffer@^1.1.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
     },
     "is-ci": {
       "version": "1.2.1",
-      "from": "is-ci@>=1.0.10 <2.0.0",
+      "from": "is-ci@^1.0.10",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
       "dev": true
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "from": "is-data-descriptor@>=0.1.4 <0.2.0",
+      "from": "is-data-descriptor@^0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz"
     },
     "is-descriptor": {
       "version": "0.1.6",
-      "from": "is-descriptor@>=0.1.0 <0.2.0",
+      "from": "is-descriptor@^0.1.0",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "dependencies": {
         "kind-of": {
           "version": "5.1.0",
-          "from": "kind-of@>=5.0.0 <6.0.0",
+          "from": "kind-of@^5.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz"
         }
       }
     },
     "is-dotfile": {
       "version": "1.0.3",
-      "from": "is-dotfile@>=1.0.0 <2.0.0",
+      "from": "is-dotfile@^1.0.0",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz"
     },
     "is-elevated": {
       "version": "1.0.0",
-      "from": "is-elevated@>=1.0.0 <2.0.0",
+      "from": "is-elevated@^1.0.0",
       "resolved": "https://registry.npmjs.org/is-elevated/-/is-elevated-1.0.0.tgz"
     },
     "is-equal-shallow": {
       "version": "0.1.3",
-      "from": "is-equal-shallow@>=0.1.3 <0.2.0",
+      "from": "is-equal-shallow@^0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
     },
     "is-even": {
       "version": "0.1.2",
-      "from": "is-even@>=0.1.1 <0.2.0",
+      "from": "is-even@^0.1.1",
       "resolved": "https://registry.npmjs.org/is-even/-/is-even-0.1.2.tgz"
     },
     "is-extendable": {
       "version": "0.1.1",
-      "from": "is-extendable@>=0.1.0 <0.2.0",
+      "from": "is-extendable@^0.1.0",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
     },
     "is-extglob": {
       "version": "1.0.0",
-      "from": "is-extglob@>=1.0.0 <2.0.0",
+      "from": "is-extglob@^1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
-      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+      "from": "is-fullwidth-code-point@^1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
     },
     "is-glob": {
       "version": "2.0.1",
-      "from": "is-glob@>=2.0.1 <3.0.0",
+      "from": "is-glob@^2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
     },
     "is-installed-globally": {
       "version": "0.1.0",
-      "from": "is-installed-globally@>=0.1.0 <0.2.0",
+      "from": "is-installed-globally@^0.1.0",
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
       "dev": true
     },
     "is-my-ip-valid": {
       "version": "1.0.0",
-      "from": "is-my-ip-valid@>=1.0.0 <2.0.0",
+      "from": "is-my-ip-valid@^1.0.0",
       "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz"
     },
     "is-my-json-valid": {
       "version": "2.19.0",
-      "from": "is-my-json-valid@>=2.12.0 <3.0.0",
+      "from": "is-my-json-valid@^2.12.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz"
     },
     "is-npm": {
       "version": "1.0.0",
-      "from": "is-npm@>=1.0.0 <2.0.0",
+      "from": "is-npm@^1.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
       "dev": true
     },
     "is-number": {
       "version": "2.1.0",
-      "from": "is-number@>=2.1.0 <3.0.0",
+      "from": "is-number@^2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
     },
     "is-obj": {
       "version": "1.0.1",
-      "from": "is-obj@>=1.0.0 <2.0.0",
+      "from": "is-obj@^1.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "dev": true
     },
     "is-odd": {
       "version": "0.1.2",
-      "from": "is-odd@>=0.1.0 <0.2.0",
+      "from": "is-odd@^0.1.0",
       "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-0.1.2.tgz",
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
-          "from": "is-number@>=3.0.0 <4.0.0",
+          "from": "is-number@^3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz"
         }
       }
     },
     "is-path-inside": {
       "version": "1.0.1",
-      "from": "is-path-inside@>=1.0.0 <2.0.0",
+      "from": "is-path-inside@^1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",
-      "from": "is-plain-object@>=2.0.4 <3.0.0",
+      "from": "is-plain-object@^2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
-          "from": "isobject@>=3.0.1 <4.0.0",
+          "from": "isobject@^3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
         }
       }
     },
     "is-posix-bracket": {
       "version": "0.1.1",
-      "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+      "from": "is-posix-bracket@^0.1.0",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
     },
     "is-primitive": {
       "version": "2.0.0",
-      "from": "is-primitive@>=2.0.0 <3.0.0",
+      "from": "is-primitive@^2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
     },
     "is-promise": {
       "version": "2.1.0",
-      "from": "is-promise@>=2.1.0 <3.0.0",
+      "from": "is-promise@^2.1",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz"
     },
     "is-property": {
       "version": "1.0.2",
-      "from": "is-property@>=1.0.2 <2.0.0",
+      "from": "is-property@^1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
     },
     "is-redirect": {
       "version": "1.0.0",
-      "from": "is-redirect@>=1.0.0 <2.0.0",
+      "from": "is-redirect@^1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "dev": true
     },
     "is-relative": {
       "version": "0.2.1",
-      "from": "is-relative@>=0.2.1 <0.3.0",
+      "from": "is-relative@^0.2.1",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz"
     },
     "is-retry-allowed": {
       "version": "1.1.0",
-      "from": "is-retry-allowed@>=1.0.0 <2.0.0",
+      "from": "is-retry-allowed@^1.0.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
       "dev": true
     },
     "is-root": {
       "version": "1.0.0",
-      "from": "is-root@>=1.0.0 <2.0.0",
+      "from": "is-root@^1.0.0",
       "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz"
     },
     "is-stream": {
       "version": "1.1.0",
-      "from": "is-stream@>=1.0.1 <2.0.0",
+      "from": "is-stream@^1.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "from": "is-typedarray@>=1.0.0 <1.1.0",
+      "from": "is-typedarray@~1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
     },
     "is-unc-path": {
       "version": "0.1.2",
-      "from": "is-unc-path@>=0.1.1 <0.2.0",
+      "from": "is-unc-path@^0.1.1",
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz"
     },
     "is-utf8": {
       "version": "0.2.1",
-      "from": "is-utf8@>=0.2.0 <0.3.0",
+      "from": "is-utf8@^0.2.0",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
     },
     "is-valid-glob": {
       "version": "0.3.0",
-      "from": "is-valid-glob@>=0.3.0 <0.4.0",
+      "from": "is-valid-glob@^0.3.0",
       "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz"
     },
     "is-windows": {
       "version": "0.2.0",
-      "from": "is-windows@>=0.2.0 <0.3.0",
+      "from": "is-windows@^0.2.0",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz"
     },
     "isarray": {
@@ -2860,60 +2860,60 @@
     },
     "isemail": {
       "version": "1.2.0",
-      "from": "isemail@>=1.0.0 <2.0.0",
+      "from": "isemail@1.x.x",
       "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
     },
     "isexe": {
       "version": "2.0.0",
-      "from": "isexe@>=2.0.0 <3.0.0",
+      "from": "isexe@^2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
     },
     "isobject": {
       "version": "0.2.0",
-      "from": "isobject@>=0.2.0 <0.3.0",
+      "from": "isobject@^0.2.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
     },
     "isstream": {
       "version": "0.1.2",
-      "from": "isstream@>=0.1.1 <0.2.0",
+      "from": "isstream@~0.1.1",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
     },
     "joi": {
       "version": "6.10.1",
-      "from": "joi@>=6.10.1 <7.0.0",
+      "from": "joi@^6.10.1",
       "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz"
     },
     "js-tokens": {
       "version": "3.0.2",
-      "from": "js-tokens@>=3.0.2 <4.0.0",
+      "from": "js-tokens@^3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "dev": true
     },
     "js-yaml": {
       "version": "3.12.1",
-      "from": "js-yaml@>=3.8.1 <4.0.0",
+      "from": "js-yaml@^3.8.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz"
     },
     "js2xmlparser": {
       "version": "3.0.0",
-      "from": "js2xmlparser@>=3.0.0 <3.1.0",
+      "from": "js2xmlparser@~3.0.0",
       "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
       "dev": true
     },
     "jsbn": {
       "version": "0.1.1",
-      "from": "jsbn@>=0.1.0 <0.2.0",
+      "from": "jsbn@~0.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
     },
     "jsdoc": {
       "version": "3.5.5",
-      "from": "jsdoc@>=3.4.3 <4.0.0",
+      "from": "jsdoc@^3.4.3",
       "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
       "dev": true,
       "dependencies": {
         "underscore": {
           "version": "1.8.3",
-          "from": "underscore@>=1.8.3 <1.9.0",
+          "from": "underscore@~1.8.3",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
           "dev": true
         }
@@ -2926,39 +2926,39 @@
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "from": "json-schema-traverse@>=0.4.1 <0.5.0",
+      "from": "json-schema-traverse@^0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz"
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "from": "json-stable-stringify-without-jsonify@>=1.0.1 <2.0.0",
+      "from": "json-stable-stringify-without-jsonify@^1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+      "from": "json-stringify-safe@~5.0.0",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
     },
     "jsonfile": {
       "version": "3.0.1",
-      "from": "jsonfile@>=3.0.0 <4.0.0",
+      "from": "jsonfile@^3.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
       "dev": true
     },
     "jsonpointer": {
       "version": "4.0.1",
-      "from": "jsonpointer@>=4.0.0 <5.0.0",
+      "from": "jsonpointer@^4.0.0",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
     },
     "jsonwebtoken": {
       "version": "7.4.3",
-      "from": "jsonwebtoken@>=7.2.1 <8.0.0",
+      "from": "jsonwebtoken@^7.2.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz"
     },
     "jsprim": {
       "version": "1.4.1",
-      "from": "jsprim@>=1.2.2 <2.0.0",
+      "from": "jsprim@^1.2.2",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "dependencies": {
         "assert-plus": {
@@ -2970,17 +2970,17 @@
     },
     "jwa": {
       "version": "1.3.0",
-      "from": "jwa@>=1.2.0 <2.0.0",
+      "from": "jwa@^1.2.0",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.3.0.tgz"
     },
     "jws": {
       "version": "3.2.1",
-      "from": "jws@>=3.1.4 <4.0.0",
+      "from": "jws@^3.1.4",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.1.tgz"
     },
     "jwt-decode": {
       "version": "2.2.0",
-      "from": "jwt-decode@>=2.1.0 <3.0.0",
+      "from": "jwt-decode@^2.1.0",
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz"
     },
     "keyfctl": {
@@ -2990,53 +2990,53 @@
     },
     "kind-of": {
       "version": "3.2.2",
-      "from": "kind-of@>=3.0.3 <4.0.0",
+      "from": "kind-of@^3.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
     },
     "klaw": {
       "version": "2.0.0",
-      "from": "klaw@>=2.0.0 <2.1.0",
+      "from": "klaw@~2.0.0",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
       "dev": true
     },
     "latest-version": {
       "version": "3.1.0",
-      "from": "latest-version@>=3.0.0 <4.0.0",
+      "from": "latest-version@^3.0.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
       "dev": true
     },
     "lazy-cache": {
       "version": "2.0.2",
-      "from": "lazy-cache@>=2.0.1 <3.0.0",
+      "from": "lazy-cache@^2.0.1",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
     },
     "lazystream": {
       "version": "1.0.0",
-      "from": "lazystream@>=1.0.0 <2.0.0",
+      "from": "lazystream@^1.0.0",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
       "dev": true,
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
+          "from": "isarray@~1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "dev": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "from": "process-nextick-args@>=2.0.0 <2.1.0",
+          "from": "process-nextick-args@~2.0.0",
           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
           "dev": true
         },
         "readable-stream": {
           "version": "2.3.6",
-          "from": "readable-stream@>=2.0.5 <3.0.0",
+          "from": "readable-stream@^2.0.5",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",
-          "from": "string_decoder@>=1.1.1 <1.2.0",
+          "from": "string_decoder@~1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "dev": true
         }
@@ -3044,23 +3044,23 @@
     },
     "lcid": {
       "version": "1.0.0",
-      "from": "lcid@>=1.0.0 <2.0.0",
+      "from": "lcid@^1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
     },
     "levn": {
       "version": "0.3.0",
-      "from": "levn@>=0.3.0 <0.4.0",
+      "from": "levn@~0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
     },
     "liftoff": {
       "version": "2.5.0",
-      "from": "liftoff@>=2.1.0 <3.0.0",
+      "from": "liftoff@^2.1.0",
       "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
       "dev": true,
       "dependencies": {
         "extend": {
           "version": "3.0.2",
-          "from": "extend@>=3.0.0 <4.0.0",
+          "from": "extend@^3.0.0",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "dev": true
         }
@@ -3068,176 +3068,176 @@
     },
     "list-item": {
       "version": "1.1.1",
-      "from": "list-item@>=1.1.1 <2.0.0",
+      "from": "list-item@^1.1.1",
       "resolved": "https://registry.npmjs.org/list-item/-/list-item-1.1.1.tgz"
     },
     "load-json-file": {
       "version": "2.0.0",
-      "from": "load-json-file@>=2.0.0 <3.0.0",
+      "from": "load-json-file@^2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz"
     },
     "locate-path": {
       "version": "2.0.0",
-      "from": "locate-path@>=2.0.0 <3.0.0",
+      "from": "locate-path@^2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz"
     },
     "lodash": {
       "version": "4.17.11",
-      "from": "lodash@>=4.17.2 <5.0.0",
+      "from": "lodash@^4.17.2",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz"
     },
     "lodash._basecopy": {
       "version": "3.0.1",
-      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+      "from": "lodash._basecopy@^3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "dev": true
     },
     "lodash._basetostring": {
       "version": "3.0.1",
-      "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+      "from": "lodash._basetostring@^3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
       "dev": true
     },
     "lodash._basevalues": {
       "version": "3.0.0",
-      "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+      "from": "lodash._basevalues@^3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
       "dev": true
     },
     "lodash._getnative": {
       "version": "3.9.1",
-      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+      "from": "lodash._getnative@^3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "dev": true
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
-      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+      "from": "lodash._isiterateecall@^3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "dev": true
     },
     "lodash._reescape": {
       "version": "3.0.0",
-      "from": "lodash._reescape@>=3.0.0 <4.0.0",
+      "from": "lodash._reescape@^3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
       "dev": true
     },
     "lodash._reevaluate": {
       "version": "3.0.0",
-      "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+      "from": "lodash._reevaluate@^3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
       "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+      "from": "lodash._reinterpolate@^3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "dev": true
     },
     "lodash._root": {
       "version": "3.0.1",
-      "from": "lodash._root@>=3.0.0 <4.0.0",
+      "from": "lodash._root@^3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
       "dev": true
     },
     "lodash.assign": {
       "version": "4.2.0",
-      "from": "lodash.assign@>=4.0.6 <5.0.0",
+      "from": "lodash.assign@^4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
     },
     "lodash.escape": {
       "version": "3.2.0",
-      "from": "lodash.escape@>=3.0.0 <4.0.0",
+      "from": "lodash.escape@^3.0.0",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
       "dev": true
     },
     "lodash.isarguments": {
       "version": "3.1.0",
-      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+      "from": "lodash.isarguments@^3.0.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "dev": true
     },
     "lodash.isarray": {
       "version": "3.0.4",
-      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+      "from": "lodash.isarray@^3.0.0",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "dev": true
     },
     "lodash.isequal": {
       "version": "4.5.0",
-      "from": "lodash.isequal@>=4.0.0 <5.0.0",
+      "from": "lodash.isequal@^4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "dev": true
     },
     "lodash.keys": {
       "version": "3.1.2",
-      "from": "lodash.keys@>=3.0.0 <4.0.0",
+      "from": "lodash.keys@^3.0.0",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2",
-      "from": "lodash.memoize@>=4.1.2 <5.0.0",
+      "from": "lodash.memoize@^4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz"
     },
     "lodash.once": {
       "version": "4.1.1",
-      "from": "lodash.once@>=4.0.0 <5.0.0",
+      "from": "lodash.once@^4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz"
     },
     "lodash.restparam": {
       "version": "3.6.1",
-      "from": "lodash.restparam@>=3.0.0 <4.0.0",
+      "from": "lodash.restparam@^3.0.0",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "dev": true
     },
     "lodash.template": {
       "version": "3.6.2",
-      "from": "lodash.template@>=3.0.0 <4.0.0",
+      "from": "lodash.template@^3.0.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
       "dev": true
     },
     "lodash.templatesettings": {
       "version": "3.1.1",
-      "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+      "from": "lodash.templatesettings@^3.0.0",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
       "dev": true
     },
     "logging-helpers": {
       "version": "0.4.0",
-      "from": "logging-helpers@>=0.4.0 <0.5.0",
+      "from": "logging-helpers@^0.4.0",
       "resolved": "https://registry.npmjs.org/logging-helpers/-/logging-helpers-0.4.0.tgz"
     },
     "lowercase-keys": {
       "version": "1.0.1",
-      "from": "lowercase-keys@>=1.0.0 <2.0.0",
+      "from": "lowercase-keys@^1.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "dev": true
     },
     "lru-cache": {
       "version": "4.1.5",
-      "from": "lru-cache@>=4.1.2 <5.0.0",
+      "from": "lru-cache@^4.1.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz"
     },
     "lru-queue": {
       "version": "0.1.0",
-      "from": "lru-queue@>=0.1.0 <0.2.0",
+      "from": "lru-queue@0.1",
       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
     },
     "macos-release": {
       "version": "2.0.0",
-      "from": "macos-release@>=2.0.0 <3.0.0",
+      "from": "macos-release@^2.0.0",
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.0.0.tgz"
     },
     "make-dir": {
       "version": "1.3.0",
-      "from": "make-dir@>=1.0.0 <2.0.0",
+      "from": "make-dir@^1.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
       "dev": true,
       "dependencies": {
         "pify": {
           "version": "3.0.0",
-          "from": "pify@>=3.0.0 <4.0.0",
+          "from": "pify@^3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "dev": true
         }
@@ -3245,51 +3245,51 @@
     },
     "make-error": {
       "version": "1.3.5",
-      "from": "make-error@>=1.1.1 <2.0.0",
+      "from": "make-error@^1.1.1",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
       "dev": true
     },
     "make-iterator": {
       "version": "0.2.1",
-      "from": "make-iterator@>=0.2.0 <0.3.0",
+      "from": "make-iterator@^0.2.0",
       "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-0.2.1.tgz"
     },
     "map-cache": {
       "version": "0.2.2",
-      "from": "map-cache@>=0.2.2 <0.3.0",
+      "from": "map-cache@^0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "dev": true
     },
     "map-stream": {
       "version": "0.1.0",
-      "from": "map-stream@>=0.1.0 <0.2.0",
+      "from": "map-stream@~0.1.0",
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
       "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
-      "from": "map-visit@>=1.0.0 <2.0.0",
+      "from": "map-visit@^1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "dev": true
     },
     "markdown": {
       "version": "0.5.0",
-      "from": "markdown@>=0.5.0 <0.6.0",
+      "from": "markdown@^0.5.0",
       "resolved": "https://registry.npmjs.org/markdown/-/markdown-0.5.0.tgz"
     },
     "markdown-utils": {
       "version": "0.7.3",
-      "from": "markdown-utils@>=0.7.3 <0.8.0",
+      "from": "markdown-utils@^0.7.3",
       "resolved": "https://registry.npmjs.org/markdown-utils/-/markdown-utils-0.7.3.tgz"
     },
     "marked": {
       "version": "0.3.19",
-      "from": "marked@>=0.3.12 <0.4.0",
+      "from": "marked@^0.3.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz"
     },
     "math-random": {
       "version": "1.0.4",
-      "from": "math-random@>=1.0.1 <2.0.0",
+      "from": "math-random@^1.0.1",
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz"
     },
     "media-typer": {
@@ -3299,12 +3299,12 @@
     },
     "mem": {
       "version": "1.1.0",
-      "from": "mem@>=1.1.0 <2.0.0",
+      "from": "mem@^1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz"
     },
     "memoizee": {
       "version": "0.4.14",
-      "from": "memoizee@>=0.4.9 <0.5.0",
+      "from": "memoizee@^0.4.9",
       "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz"
     },
     "merge-descriptors": {
@@ -3314,31 +3314,31 @@
     },
     "merge-stream": {
       "version": "1.0.1",
-      "from": "merge-stream@>=1.0.0 <2.0.0",
+      "from": "merge-stream@^1.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
       "dev": true,
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
+          "from": "isarray@~1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "dev": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "from": "process-nextick-args@>=2.0.0 <2.1.0",
+          "from": "process-nextick-args@~2.0.0",
           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
           "dev": true
         },
         "readable-stream": {
           "version": "2.3.6",
-          "from": "readable-stream@>=2.0.1 <3.0.0",
+          "from": "readable-stream@^2.0.1",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",
-          "from": "string_decoder@>=1.1.1 <1.2.0",
+          "from": "string_decoder@~1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "dev": true
         }
@@ -3346,12 +3346,12 @@
     },
     "methods": {
       "version": "1.1.2",
-      "from": "methods@>=1.1.2 <1.2.0",
+      "from": "methods@~1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
     },
     "micromatch": {
       "version": "2.3.11",
-      "from": "micromatch@>=2.3.10 <3.0.0",
+      "from": "micromatch@^2.3.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
     },
     "mime": {
@@ -3361,22 +3361,22 @@
     },
     "mime-db": {
       "version": "1.38.0",
-      "from": "mime-db@>=1.38.0 <1.39.0",
+      "from": "mime-db@~1.38.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz"
     },
     "mime-types": {
       "version": "2.1.22",
-      "from": "mime-types@>=2.1.18 <2.2.0",
+      "from": "mime-types@~2.1.18",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz"
     },
     "mimic-fn": {
       "version": "1.2.0",
-      "from": "mimic-fn@>=1.0.0 <2.0.0",
+      "from": "mimic-fn@^1.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz"
     },
     "minimatch": {
       "version": "3.0.4",
-      "from": "minimatch@>=3.0.4 <4.0.0",
+      "from": "minimatch@^3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
     },
     "minimist": {
@@ -3386,29 +3386,29 @@
     },
     "mixin-deep": {
       "version": "1.3.1",
-      "from": "mixin-deep@>=1.1.3 <2.0.0",
+      "from": "mixin-deep@^1.1.3",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
       "dependencies": {
         "for-in": {
           "version": "1.0.2",
-          "from": "for-in@>=1.0.2 <2.0.0",
+          "from": "for-in@^1.0.2",
           "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
         },
         "is-extendable": {
           "version": "1.0.1",
-          "from": "is-extendable@>=1.0.1 <2.0.0",
+          "from": "is-extendable@^1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz"
         }
       }
     },
     "mkdirp": {
       "version": "0.5.1",
-      "from": "mkdirp@>=0.5.1 <0.6.0",
+      "from": "mkdirp@^0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
     },
     "mocha": {
       "version": "4.1.0",
-      "from": "mocha@>=4.0.1 <5.0.0",
+      "from": "mocha@^4.0.1",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
       "dev": true,
       "dependencies": {
@@ -3432,7 +3432,7 @@
         },
         "has-flag": {
           "version": "2.0.0",
-          "from": "has-flag@>=2.0.0 <3.0.0",
+          "from": "has-flag@^2.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
           "dev": true
         },
@@ -3446,7 +3446,7 @@
     },
     "moment": {
       "version": "2.24.0",
-      "from": "moment@>=2.18.1 <3.0.0",
+      "from": "moment@^2.18.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz"
     },
     "ms": {
@@ -3456,79 +3456,79 @@
     },
     "multipipe": {
       "version": "0.1.2",
-      "from": "multipipe@>=0.1.2 <0.2.0",
+      "from": "multipipe@^0.1.2",
       "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
       "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
-      "from": "nanomatch@>=1.2.9 <2.0.0",
+      "from": "nanomatch@^1.2.9",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
       "dev": true,
       "dependencies": {
         "arr-diff": {
           "version": "4.0.0",
-          "from": "arr-diff@>=4.0.0 <5.0.0",
+          "from": "arr-diff@^4.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
           "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
-          "from": "array-unique@>=0.3.2 <0.4.0",
+          "from": "array-unique@^0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
           "dev": true
         },
         "define-property": {
           "version": "2.0.2",
-          "from": "define-property@>=2.0.2 <3.0.0",
+          "from": "define-property@^2.0.2",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
           "dev": true
         },
         "extend-shallow": {
           "version": "3.0.2",
-          "from": "extend-shallow@>=3.0.2 <4.0.0",
+          "from": "extend-shallow@^3.0.2",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "dev": true
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "from": "is-accessor-descriptor@>=1.0.0 <2.0.0",
+          "from": "is-accessor-descriptor@^1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "dev": true
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "from": "is-data-descriptor@>=1.0.0 <2.0.0",
+          "from": "is-data-descriptor@^1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "dev": true
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "from": "is-descriptor@>=1.0.2 <2.0.0",
+          "from": "is-descriptor@^1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "dev": true
         },
         "is-extendable": {
           "version": "1.0.1",
-          "from": "is-extendable@>=1.0.1 <2.0.0",
+          "from": "is-extendable@^1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "dev": true
         },
         "is-windows": {
           "version": "1.0.2",
-          "from": "is-windows@>=1.0.2 <2.0.0",
+          "from": "is-windows@^1.0.2",
           "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
           "dev": true
         },
         "isobject": {
           "version": "3.0.1",
-          "from": "isobject@>=3.0.1 <4.0.0",
+          "from": "isobject@^3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "dev": true
         },
         "kind-of": {
           "version": "6.0.2",
-          "from": "kind-of@>=6.0.2 <7.0.0",
+          "from": "kind-of@^6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "dev": true
         }
@@ -3536,7 +3536,7 @@
     },
     "natives": {
       "version": "1.1.6",
-      "from": "natives@>=1.1.0 <2.0.0",
+      "from": "natives@^1.1.0",
       "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
       "dev": true
     },
@@ -3547,42 +3547,42 @@
     },
     "netmask": {
       "version": "1.0.6",
-      "from": "netmask@>=1.0.6 <2.0.0",
+      "from": "netmask@^1.0.6",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz"
     },
     "netrc": {
       "version": "0.1.4",
-      "from": "netrc@>=0.1.4 <0.2.0",
+      "from": "netrc@^0.1.4",
       "resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz"
     },
     "next-tick": {
       "version": "1.0.0",
-      "from": "next-tick@>=1.0.0 <2.0.0",
+      "from": "next-tick@1",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz"
     },
     "nice-try": {
       "version": "1.0.5",
-      "from": "nice-try@>=1.0.4 <2.0.0",
+      "from": "nice-try@^1.0.4",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz"
     },
     "node-fetch": {
       "version": "1.7.3",
-      "from": "node-fetch@>=1.7.1 <1.8.0",
+      "from": "node-fetch@~1.7.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz"
     },
     "node-getopt": {
       "version": "0.2.4",
-      "from": "node-getopt@>=0.2.3 <0.3.0",
+      "from": "node-getopt@^0.2.3",
       "resolved": "https://registry.npmjs.org/node-getopt/-/node-getopt-0.2.4.tgz"
     },
     "node-localstorage": {
       "version": "1.3.1",
-      "from": "node-localstorage@>=1.3.0 <2.0.0",
+      "from": "node-localstorage@^1.3.0",
       "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.1.tgz"
     },
     "node-uuid": {
       "version": "1.4.8",
-      "from": "node-uuid@>=1.4.0 <1.5.0",
+      "from": "node-uuid@~1.4.0",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz"
     },
     "node.extend": {
@@ -3597,32 +3597,32 @@
     },
     "nopt": {
       "version": "2.1.2",
-      "from": "nopt@>=2.1.1 <2.2.0",
+      "from": "nopt@~2.1.1",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz"
     },
     "normalize-package-data": {
       "version": "2.5.0",
-      "from": "normalize-package-data@>=2.3.2 <3.0.0",
+      "from": "normalize-package-data@^2.3.2",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz"
     },
     "normalize-path": {
       "version": "2.1.1",
-      "from": "normalize-path@>=2.0.1 <3.0.0",
+      "from": "normalize-path@^2.0.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz"
     },
     "npm-run-path": {
       "version": "2.0.2",
-      "from": "npm-run-path@>=2.0.0 <3.0.0",
+      "from": "npm-run-path@^2.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz"
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "from": "number-is-nan@>=1.0.0 <2.0.0",
+      "from": "number-is-nan@^1.0.0",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
     },
     "nyc": {
       "version": "11.9.0",
-      "from": "nyc@>=11.3.0 <12.0.0",
+      "from": "nyc@^11.3.0",
       "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.9.0.tgz",
       "dev": true,
       "dependencies": {
@@ -5700,35 +5700,35 @@
     },
     "oauth-sign": {
       "version": "0.8.2",
-      "from": "oauth-sign@>=0.8.0 <0.9.0",
+      "from": "oauth-sign@~0.8.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
     },
     "object-assign": {
       "version": "3.0.0",
-      "from": "object-assign@>=3.0.0 <4.0.0",
+      "from": "object-assign@^3.0.0",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
       "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
-      "from": "object-copy@>=0.1.0 <0.2.0",
+      "from": "object-copy@^0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "dev": true
     },
     "object-keys": {
       "version": "0.4.0",
-      "from": "object-keys@>=0.4.0 <0.5.0",
+      "from": "object-keys@~0.4.0",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
     },
     "object-visit": {
       "version": "1.0.1",
-      "from": "object-visit@>=1.0.0 <2.0.0",
+      "from": "object-visit@^1.0.0",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "dev": true,
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
-          "from": "isobject@>=3.0.0 <4.0.0",
+          "from": "isobject@^3.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "dev": true
         }
@@ -5736,31 +5736,31 @@
     },
     "object.defaults": {
       "version": "1.1.0",
-      "from": "object.defaults@>=1.1.0 <2.0.0",
+      "from": "object.defaults@^1.1.0",
       "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
       "dev": true,
       "dependencies": {
         "array-slice": {
           "version": "1.1.0",
-          "from": "array-slice@>=1.0.0 <2.0.0",
+          "from": "array-slice@^1.0.0",
           "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
           "dev": true
         },
         "for-in": {
           "version": "1.0.2",
-          "from": "for-in@>=1.0.1 <2.0.0",
+          "from": "for-in@^1.0.1",
           "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "dev": true
         },
         "for-own": {
           "version": "1.0.0",
-          "from": "for-own@>=1.0.0 <2.0.0",
+          "from": "for-own@^1.0.0",
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
           "dev": true
         },
         "isobject": {
           "version": "3.0.1",
-          "from": "isobject@>=3.0.0 <4.0.0",
+          "from": "isobject@^3.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "dev": true
         }
@@ -5768,31 +5768,31 @@
     },
     "object.map": {
       "version": "1.0.1",
-      "from": "object.map@>=1.0.0 <2.0.0",
+      "from": "object.map@^1.0.0",
       "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
       "dev": true,
       "dependencies": {
         "for-in": {
           "version": "1.0.2",
-          "from": "for-in@>=1.0.1 <2.0.0",
+          "from": "for-in@^1.0.1",
           "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "dev": true
         },
         "for-own": {
           "version": "1.0.0",
-          "from": "for-own@>=1.0.0 <2.0.0",
+          "from": "for-own@^1.0.0",
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
           "dev": true
         },
         "kind-of": {
           "version": "6.0.2",
-          "from": "kind-of@>=6.0.2 <7.0.0",
+          "from": "kind-of@^6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "dev": true
         },
         "make-iterator": {
           "version": "1.0.1",
-          "from": "make-iterator@>=1.0.0 <2.0.0",
+          "from": "make-iterator@^1.0.0",
           "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
           "dev": true
         }
@@ -5800,18 +5800,18 @@
     },
     "object.omit": {
       "version": "2.0.1",
-      "from": "object.omit@>=2.0.0 <3.0.0",
+      "from": "object.omit@^2.0.0",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz"
     },
     "object.pick": {
       "version": "1.3.0",
-      "from": "object.pick@>=1.3.0 <2.0.0",
+      "from": "object.pick@^1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "dev": true,
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
-          "from": "isobject@>=3.0.1 <4.0.0",
+          "from": "isobject@^3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "dev": true
         }
@@ -5819,141 +5819,141 @@
     },
     "omit-empty": {
       "version": "0.4.1",
-      "from": "omit-empty@>=0.4.1 <0.5.0",
+      "from": "omit-empty@^0.4.1",
       "resolved": "https://registry.npmjs.org/omit-empty/-/omit-empty-0.4.1.tgz"
     },
     "on-finished": {
       "version": "2.3.0",
-      "from": "on-finished@>=2.3.0 <2.4.0",
+      "from": "on-finished@~2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
     },
     "once": {
       "version": "1.4.0",
-      "from": "once@>=1.3.0 <2.0.0",
+      "from": "once@^1.3.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
     },
     "optimist": {
       "version": "0.6.1",
-      "from": "optimist@>=0.6.1 <0.7.0",
+      "from": "optimist@^0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "dependencies": {
         "wordwrap": {
           "version": "0.0.3",
-          "from": "wordwrap@>=0.0.2 <0.1.0",
+          "from": "wordwrap@~0.0.2",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
         }
       }
     },
     "optionator": {
       "version": "0.8.2",
-      "from": "optionator@>=0.8.1 <0.9.0",
+      "from": "optionator@^0.8.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz"
     },
     "orchestrator": {
       "version": "0.3.8",
-      "from": "orchestrator@>=0.3.0 <0.4.0",
+      "from": "orchestrator@^0.3.0",
       "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
       "dev": true
     },
     "ordered-read-streams": {
       "version": "0.1.0",
-      "from": "ordered-read-streams@>=0.1.0 <0.2.0",
+      "from": "ordered-read-streams@^0.1.0",
       "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
       "dev": true
     },
     "os-homedir": {
       "version": "1.0.2",
-      "from": "os-homedir@>=1.0.0 <2.0.0",
+      "from": "os-homedir@^1.0.0",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
     },
     "os-locale": {
       "version": "2.1.0",
-      "from": "os-locale@>=2.0.0 <3.0.0",
+      "from": "os-locale@^2.0.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
       "dependencies": {
         "cross-spawn": {
           "version": "5.1.0",
-          "from": "cross-spawn@>=5.0.1 <6.0.0",
+          "from": "cross-spawn@^5.0.1",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz"
         },
         "execa": {
           "version": "0.7.0",
-          "from": "execa@>=0.7.0 <0.8.0",
+          "from": "execa@^0.7.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz"
         }
       }
     },
     "os-name": {
       "version": "3.0.0",
-      "from": "os-name@>=3.0.0 <4.0.0",
+      "from": "os-name@^3.0.0",
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.0.0.tgz"
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "from": "os-tmpdir@>=1.0.1 <2.0.0",
+      "from": "os-tmpdir@^1.0.1",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
     },
     "p-finally": {
       "version": "1.0.0",
-      "from": "p-finally@>=1.0.0 <2.0.0",
+      "from": "p-finally@^1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz"
     },
     "p-limit": {
       "version": "1.3.0",
-      "from": "p-limit@>=1.1.0 <2.0.0",
+      "from": "p-limit@^1.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz"
     },
     "p-locate": {
       "version": "2.0.0",
-      "from": "p-locate@>=2.0.0 <3.0.0",
+      "from": "p-locate@^2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz"
     },
     "p-try": {
       "version": "1.0.0",
-      "from": "p-try@>=1.0.0 <2.0.0",
+      "from": "p-try@^1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz"
     },
     "pac-proxy-agent": {
       "version": "2.0.2",
-      "from": "pac-proxy-agent@>=2.0.1 <3.0.0",
+      "from": "pac-proxy-agent@^2.0.1",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-2.0.2.tgz",
       "dependencies": {
         "agent-base": {
           "version": "4.2.1",
-          "from": "agent-base@>=4.2.0 <5.0.0",
+          "from": "agent-base@^4.2.0",
           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz"
         },
         "debug": {
           "version": "3.2.6",
-          "from": "debug@>=3.1.0 <4.0.0",
+          "from": "debug@^3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz"
         },
         "https-proxy-agent": {
           "version": "2.2.1",
-          "from": "https-proxy-agent@>=2.2.1 <3.0.0",
+          "from": "https-proxy-agent@^2.2.1",
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz"
         },
         "ms": {
           "version": "2.1.1",
-          "from": "ms@>=2.1.1 <3.0.0",
+          "from": "ms@^2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz"
         }
       }
     },
     "pac-resolver": {
       "version": "3.0.0",
-      "from": "pac-resolver@>=3.0.0 <4.0.0",
+      "from": "pac-resolver@^3.0.0",
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-3.0.0.tgz"
     },
     "package-json": {
       "version": "4.0.1",
-      "from": "package-json@>=4.0.0 <5.0.0",
+      "from": "package-json@^4.0.0",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
       "dev": true,
       "dependencies": {
         "semver": {
           "version": "5.6.0",
-          "from": "semver@>=5.1.0 <6.0.0",
+          "from": "semver@^5.1.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
           "dev": true
         }
@@ -5961,41 +5961,41 @@
     },
     "parse-author": {
       "version": "1.0.0",
-      "from": "parse-author@>=1.0.0 <2.0.0",
+      "from": "parse-author@^1.0.0",
       "resolved": "https://registry.npmjs.org/parse-author/-/parse-author-1.0.0.tgz"
     },
     "parse-code-context": {
       "version": "0.1.3",
-      "from": "parse-code-context@>=0.1.3 <0.2.0",
+      "from": "parse-code-context@^0.1.3",
       "resolved": "https://registry.npmjs.org/parse-code-context/-/parse-code-context-0.1.3.tgz"
     },
     "parse-filepath": {
       "version": "1.0.2",
-      "from": "parse-filepath@>=1.0.1 <2.0.0",
+      "from": "parse-filepath@^1.0.1",
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
       "dev": true,
       "dependencies": {
         "is-absolute": {
           "version": "1.0.0",
-          "from": "is-absolute@>=1.0.0 <2.0.0",
+          "from": "is-absolute@^1.0.0",
           "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
           "dev": true
         },
         "is-relative": {
           "version": "1.0.0",
-          "from": "is-relative@>=1.0.0 <2.0.0",
+          "from": "is-relative@^1.0.0",
           "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
           "dev": true
         },
         "is-unc-path": {
           "version": "1.0.0",
-          "from": "is-unc-path@>=1.0.0 <2.0.0",
+          "from": "is-unc-path@^1.0.0",
           "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
           "dev": true
         },
         "is-windows": {
           "version": "1.0.2",
-          "from": "is-windows@>=1.0.1 <2.0.0",
+          "from": "is-windows@^1.0.1",
           "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
           "dev": true
         }
@@ -6003,87 +6003,87 @@
     },
     "parse-git-config": {
       "version": "1.1.1",
-      "from": "parse-git-config@>=1.0.2 <2.0.0",
+      "from": "parse-git-config@^1.0.2",
       "resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-1.1.1.tgz"
     },
     "parse-github-url": {
       "version": "0.3.2",
-      "from": "parse-github-url@>=0.3.2 <0.4.0",
+      "from": "parse-github-url@^0.3.2",
       "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-0.3.2.tgz"
     },
     "parse-glob": {
       "version": "3.0.4",
-      "from": "parse-glob@>=3.0.4 <4.0.0",
+      "from": "parse-glob@^3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
     },
     "parse-json": {
       "version": "2.2.0",
-      "from": "parse-json@>=2.2.0 <3.0.0",
+      "from": "parse-json@^2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
     },
     "parse-node-version": {
       "version": "1.0.1",
-      "from": "parse-node-version@>=1.0.0 <2.0.0",
+      "from": "parse-node-version@^1.0.0",
       "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
       "dev": true
     },
     "parse-passwd": {
       "version": "1.0.0",
-      "from": "parse-passwd@>=1.0.0 <2.0.0",
+      "from": "parse-passwd@^1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz"
     },
     "parseurl": {
       "version": "1.3.2",
-      "from": "parseurl@>=1.3.2 <1.4.0",
+      "from": "parseurl@~1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz"
     },
     "pascalcase": {
       "version": "0.1.1",
-      "from": "pascalcase@>=0.1.1 <0.2.0",
+      "from": "pascalcase@^0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "dev": true
     },
     "path-dirname": {
       "version": "1.0.2",
-      "from": "path-dirname@>=1.0.0 <2.0.0",
+      "from": "path-dirname@^1.0.0",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
-      "from": "path-exists@>=3.0.0 <4.0.0",
+      "from": "path-exists@^3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz"
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+      "from": "path-is-absolute@^1.0.0",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "from": "path-is-inside@>=1.0.1 <2.0.0",
+      "from": "path-is-inside@^1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "dev": true
     },
     "path-key": {
       "version": "2.0.1",
-      "from": "path-key@>=2.0.1 <3.0.0",
+      "from": "path-key@^2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz"
     },
     "path-parse": {
       "version": "1.0.6",
-      "from": "path-parse@>=1.0.6 <2.0.0",
+      "from": "path-parse@^1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz"
     },
     "path-root": {
       "version": "0.1.1",
-      "from": "path-root@>=0.1.1 <0.2.0",
+      "from": "path-root@^0.1.1",
       "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
       "dev": true
     },
     "path-root-regex": {
       "version": "0.1.2",
-      "from": "path-root-regex@>=0.1.0 <0.2.0",
+      "from": "path-root-regex@^0.1.0",
       "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
       "dev": true
     },
@@ -6094,148 +6094,148 @@
     },
     "path-type": {
       "version": "2.0.0",
-      "from": "path-type@>=2.0.0 <3.0.0",
+      "from": "path-type@^2.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz"
     },
     "pathval": {
       "version": "1.1.0",
-      "from": "pathval@>=1.1.0 <2.0.0",
+      "from": "pathval@^1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
-      "from": "performance-now@>=2.1.0 <3.0.0",
+      "from": "performance-now@^2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz"
     },
     "pify": {
       "version": "2.3.0",
-      "from": "pify@>=2.0.0 <3.0.0",
+      "from": "pify@^2.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
     },
     "pinejs-client": {
       "version": "3.1.0",
-      "from": "pinejs-client@>=3.1.0 <4.0.0",
+      "from": "pinejs-client@^3.1.0",
       "resolved": "https://registry.npmjs.org/pinejs-client/-/pinejs-client-3.1.0.tgz",
       "dependencies": {
         "typed-error": {
           "version": "0.1.0",
-          "from": "typed-error@>=0.1.0 <0.2.0",
+          "from": "typed-error@^0.1.0",
           "resolved": "https://registry.npmjs.org/typed-error/-/typed-error-0.1.0.tgz"
         }
       }
     },
     "posix-character-classes": {
       "version": "0.1.1",
-      "from": "posix-character-classes@>=0.1.0 <0.2.0",
+      "from": "posix-character-classes@^0.1.0",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "from": "prelude-ls@>=1.1.2 <1.2.0",
+      "from": "prelude-ls@~1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
     },
     "prepend-http": {
       "version": "1.0.4",
-      "from": "prepend-http@>=1.0.1 <2.0.0",
+      "from": "prepend-http@^1.0.1",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "dev": true
     },
     "preserve": {
       "version": "0.2.0",
-      "from": "preserve@>=0.2.0 <0.3.0",
+      "from": "preserve@^0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
     },
     "pretty-hrtime": {
       "version": "1.0.3",
-      "from": "pretty-hrtime@>=1.0.0 <2.0.0",
+      "from": "pretty-hrtime@^1.0.0",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "dev": true
     },
     "process-nextick-args": {
       "version": "1.0.7",
-      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+      "from": "process-nextick-args@~1.0.6",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
     },
     "progress": {
       "version": "2.0.3",
-      "from": "progress@>=2.0.0 <3.0.0",
+      "from": "progress@^2.0.0",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "dev": true
     },
     "progress-stream": {
       "version": "2.0.0",
-      "from": "progress-stream@>=2.0.0 <3.0.0",
+      "from": "progress-stream@^2.0.0",
       "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-2.0.0.tgz"
     },
     "project-name": {
       "version": "0.2.6",
-      "from": "project-name@>=0.2.6 <0.3.0",
+      "from": "project-name@^0.2.6",
       "resolved": "https://registry.npmjs.org/project-name/-/project-name-0.2.6.tgz",
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.2.0 <2.0.0",
+          "from": "minimist@^1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         }
       }
     },
     "promise-memoize": {
       "version": "1.2.1",
-      "from": "promise-memoize@>=1.2.0 <2.0.0",
+      "from": "promise-memoize@^1.2.0",
       "resolved": "https://registry.npmjs.org/promise-memoize/-/promise-memoize-1.2.1.tgz"
     },
     "proxy-addr": {
       "version": "2.0.4",
-      "from": "proxy-addr@>=2.0.4 <2.1.0",
+      "from": "proxy-addr@~2.0.4",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz"
     },
     "proxy-agent": {
       "version": "2.3.1",
-      "from": "proxy-agent@>=2.0.0 <3.0.0",
+      "from": "proxy-agent@2",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-2.3.1.tgz",
       "dependencies": {
         "agent-base": {
           "version": "4.2.1",
-          "from": "agent-base@>=4.2.0 <5.0.0",
+          "from": "agent-base@^4.2.0",
           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz"
         },
         "debug": {
           "version": "3.2.6",
-          "from": "debug@>=3.1.0 <4.0.0",
+          "from": "debug@^3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz"
         },
         "https-proxy-agent": {
           "version": "2.2.1",
-          "from": "https-proxy-agent@>=2.2.1 <3.0.0",
+          "from": "https-proxy-agent@^2.2.1",
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz"
         },
         "ms": {
           "version": "2.1.1",
-          "from": "ms@>=2.1.1 <3.0.0",
+          "from": "ms@^2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz"
         }
       }
     },
     "proxy-from-env": {
       "version": "1.0.0",
-      "from": "proxy-from-env@>=1.0.0 <2.0.0",
+      "from": "proxy-from-env@^1.0.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz"
     },
     "pseudomap": {
       "version": "1.0.2",
-      "from": "pseudomap@>=1.0.2 <2.0.0",
+      "from": "pseudomap@^1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
     },
     "psl": {
       "version": "1.1.31",
-      "from": "psl@>=1.1.28 <2.0.0",
+      "from": "psl@^1.1.28",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz"
     },
     "pubnub": {
       "version": "4.15.1",
-      "from": "pubnub@>=4.15.0 <4.16.0",
+      "from": "pubnub@~4.15.0",
       "resolved": "https://registry.npmjs.org/pubnub/-/pubnub-4.15.1.tgz",
       "dependencies": {
         "uuid": {
@@ -6247,7 +6247,7 @@
     },
     "punycode": {
       "version": "2.1.1",
-      "from": "punycode@>=2.1.1 <3.0.0",
+      "from": "punycode@^2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz"
     },
     "qs": {
@@ -6257,29 +6257,29 @@
     },
     "randomatic": {
       "version": "3.1.1",
-      "from": "randomatic@>=3.0.0 <4.0.0",
+      "from": "randomatic@^3.0.0",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
       "dependencies": {
         "is-number": {
           "version": "4.0.0",
-          "from": "is-number@>=4.0.0 <5.0.0",
+          "from": "is-number@^4.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz"
         },
         "kind-of": {
           "version": "6.0.2",
-          "from": "kind-of@>=6.0.0 <7.0.0",
+          "from": "kind-of@^6.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz"
         }
       }
     },
     "randomstring": {
       "version": "1.1.5",
-      "from": "randomstring@>=1.1.5 <2.0.0",
+      "from": "randomstring@^1.1.5",
       "resolved": "https://registry.npmjs.org/randomstring/-/randomstring-1.1.5.tgz"
     },
     "range-parser": {
       "version": "1.2.0",
-      "from": "range-parser@>=1.2.0 <1.3.0",
+      "from": "range-parser@~1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
     },
     "raw-body": {
@@ -6289,13 +6289,13 @@
     },
     "rc": {
       "version": "1.2.8",
-      "from": "rc@>=1.1.6 <2.0.0",
+      "from": "rc@^1.1.6",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "dev": true,
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.2.0 <2.0.0",
+          "from": "minimist@^1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "dev": true
         }
@@ -6303,50 +6303,50 @@
     },
     "read-pkg": {
       "version": "2.0.0",
-      "from": "read-pkg@>=2.0.0 <3.0.0",
+      "from": "read-pkg@^2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz"
     },
     "read-pkg-up": {
       "version": "2.0.0",
-      "from": "read-pkg-up@>=2.0.0 <3.0.0",
+      "from": "read-pkg-up@^2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz"
     },
     "readable-stream": {
       "version": "1.0.34",
-      "from": "readable-stream@>=1.0.26 <1.1.0",
+      "from": "readable-stream@~1.0.26",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
     },
     "rechoir": {
       "version": "0.6.2",
-      "from": "rechoir@>=0.6.2 <0.7.0",
+      "from": "rechoir@^0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "dev": true
     },
     "reduce-object": {
       "version": "0.1.3",
-      "from": "reduce-object@>=0.1.3 <0.2.0",
+      "from": "reduce-object@^0.1.3",
       "resolved": "https://registry.npmjs.org/reduce-object/-/reduce-object-0.1.3.tgz"
     },
     "regex-cache": {
       "version": "0.4.4",
-      "from": "regex-cache@>=0.4.2 <0.5.0",
+      "from": "regex-cache@^0.4.2",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz"
     },
     "regex-not": {
       "version": "1.0.2",
-      "from": "regex-not@>=1.0.0 <2.0.0",
+      "from": "regex-not@^1.0.0",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "dev": true,
       "dependencies": {
         "extend-shallow": {
           "version": "3.0.2",
-          "from": "extend-shallow@>=3.0.2 <4.0.0",
+          "from": "extend-shallow@^3.0.2",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "dev": true
         },
         "is-extendable": {
           "version": "1.0.1",
-          "from": "is-extendable@>=1.0.1 <2.0.0",
+          "from": "is-extendable@^1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "dev": true
         }
@@ -6354,19 +6354,19 @@
     },
     "registry-auth-token": {
       "version": "3.3.2",
-      "from": "registry-auth-token@>=3.0.1 <4.0.0",
+      "from": "registry-auth-token@^3.0.1",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
       "dev": true
     },
     "registry-url": {
       "version": "3.1.0",
-      "from": "registry-url@>=3.0.3 <4.0.0",
+      "from": "registry-url@^3.0.3",
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "dev": true
     },
     "relative": {
       "version": "3.0.2",
-      "from": "relative@>=3.0.2 <4.0.0",
+      "from": "relative@^3.0.2",
       "resolved": "https://registry.npmjs.org/relative/-/relative-3.0.2.tgz",
       "dependencies": {
         "isarray": {
@@ -6376,46 +6376,46 @@
         },
         "isobject": {
           "version": "2.1.0",
-          "from": "isobject@>=2.0.0 <3.0.0",
+          "from": "isobject@^2.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
         }
       }
     },
     "remarkable": {
       "version": "1.7.1",
-      "from": "remarkable@>=1.6.0 <2.0.0",
+      "from": "remarkable@^1.6.0",
       "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz",
       "dependencies": {
         "argparse": {
           "version": "0.1.16",
-          "from": "argparse@>=0.1.15 <0.2.0",
+          "from": "argparse@~0.1.15",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz"
         },
         "underscore.string": {
           "version": "2.4.0",
-          "from": "underscore.string@>=2.4.0 <2.5.0",
+          "from": "underscore.string@~2.4.0",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
         }
       }
     },
     "remote-origin-url": {
       "version": "0.5.3",
-      "from": "remote-origin-url@>=0.5.1 <0.6.0",
+      "from": "remote-origin-url@^0.5.1",
       "resolved": "https://registry.npmjs.org/remote-origin-url/-/remote-origin-url-0.5.3.tgz"
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+      "from": "remove-trailing-separator@^1.0.1",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz"
     },
     "repeat-element": {
       "version": "1.1.3",
-      "from": "repeat-element@>=1.1.2 <2.0.0",
+      "from": "repeat-element@^1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz"
     },
     "repeat-string": {
       "version": "1.6.1",
-      "from": "repeat-string@>=1.5.2 <2.0.0",
+      "from": "repeat-string@^1.5.2",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
     },
     "replace-ext": {
@@ -6425,121 +6425,121 @@
     },
     "replace-in-file": {
       "version": "2.6.4",
-      "from": "replace-in-file@>=2.5.0 <3.0.0",
+      "from": "replace-in-file@^2.5.0",
       "resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-2.6.4.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "from": "ansi-styles@>=3.2.1 <4.0.0",
+          "from": "ansi-styles@^3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz"
         },
         "camelcase": {
           "version": "4.1.0",
-          "from": "camelcase@>=4.1.0 <5.0.0",
+          "from": "camelcase@^4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
         },
         "chalk": {
           "version": "2.4.2",
-          "from": "chalk@>=2.1.0 <3.0.0",
+          "from": "chalk@^2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
         },
         "supports-color": {
           "version": "5.5.0",
-          "from": "supports-color@>=5.3.0 <6.0.0",
+          "from": "supports-color@^5.3.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz"
         },
         "yargs": {
           "version": "8.0.2",
-          "from": "yargs@>=8.0.2 <9.0.0",
+          "from": "yargs@^8.0.2",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz"
         },
         "yargs-parser": {
           "version": "7.0.0",
-          "from": "yargs-parser@>=7.0.0 <8.0.0",
+          "from": "yargs-parser@^7.0.0",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz"
         }
       }
     },
     "repo-utils": {
       "version": "0.3.7",
-      "from": "repo-utils@>=0.3.4 <0.4.0",
+      "from": "repo-utils@^0.3.4",
       "resolved": "https://registry.npmjs.org/repo-utils/-/repo-utils-0.3.7.tgz"
     },
     "request": {
       "version": "2.88.0",
-      "from": "request@>=2.79.0 <3.0.0",
+      "from": "request@^2.79.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "from": "assert-plus@^1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "from": "aws-sign2@>=0.7.0 <0.8.0",
+          "from": "aws-sign2@~0.7.0",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz"
         },
         "caseless": {
           "version": "0.12.0",
-          "from": "caseless@>=0.12.0 <0.13.0",
+          "from": "caseless@~0.12.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
         },
         "extend": {
           "version": "3.0.2",
-          "from": "extend@>=3.0.2 <3.1.0",
+          "from": "extend@~3.0.2",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
         },
         "form-data": {
           "version": "2.3.3",
-          "from": "form-data@>=2.3.2 <2.4.0",
+          "from": "form-data@~2.3.2",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz"
         },
         "har-validator": {
           "version": "5.1.3",
-          "from": "har-validator@>=5.1.0 <5.2.0",
+          "from": "har-validator@~5.1.0",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz"
         },
         "http-signature": {
           "version": "1.2.0",
-          "from": "http-signature@>=1.2.0 <1.3.0",
+          "from": "http-signature@~1.2.0",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz"
         },
         "oauth-sign": {
           "version": "0.9.0",
-          "from": "oauth-sign@>=0.9.0 <0.10.0",
+          "from": "oauth-sign@~0.9.0",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz"
         },
         "punycode": {
           "version": "1.4.1",
-          "from": "punycode@>=1.4.1 <2.0.0",
+          "from": "punycode@^1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
         },
         "tough-cookie": {
           "version": "2.4.3",
-          "from": "tough-cookie@>=2.4.3 <2.5.0",
+          "from": "tough-cookie@~2.4.3",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz"
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "from": "tunnel-agent@>=0.6.0 <0.7.0",
+          "from": "tunnel-agent@^0.6.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
         },
         "uuid": {
           "version": "3.3.2",
-          "from": "uuid@>=3.3.2 <4.0.0",
+          "from": "uuid@^3.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz"
         }
       }
     },
     "request-promise": {
       "version": "4.2.4",
-      "from": "request-promise@>=4.1.1 <5.0.0",
+      "from": "request-promise@^4.1.1",
       "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.4.tgz",
       "dependencies": {
         "tough-cookie": {
           "version": "2.5.0",
-          "from": "tough-cookie@>=2.3.3 <3.0.0",
+          "from": "tough-cookie@^2.3.3",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz"
         }
       }
@@ -6551,23 +6551,23 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "from": "require-directory@>=2.1.1 <3.0.0",
+      "from": "require-directory@^2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
     },
     "require-main-filename": {
       "version": "1.0.1",
-      "from": "require-main-filename@>=1.0.1 <2.0.0",
+      "from": "require-main-filename@^1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
     },
     "requizzle": {
       "version": "0.2.1",
-      "from": "requizzle@>=0.2.1 <0.3.0",
+      "from": "requizzle@~0.2.1",
       "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
       "dev": true,
       "dependencies": {
         "underscore": {
           "version": "1.6.0",
-          "from": "underscore@>=1.6.0 <1.7.0",
+          "from": "underscore@~1.6.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "dev": true
         }
@@ -6575,68 +6575,68 @@
     },
     "resin-device-logs": {
       "version": "3.2.1",
-      "from": "resin-device-logs@>=3.1.0 <4.0.0",
+      "from": "resin-device-logs@^3.1.0",
       "resolved": "https://registry.npmjs.org/resin-device-logs/-/resin-device-logs-3.2.1.tgz"
     },
     "resin-device-status": {
       "version": "1.1.1",
-      "from": "resin-device-status@>=1.0.1 <2.0.0",
+      "from": "resin-device-status@^1.0.1",
       "resolved": "https://registry.npmjs.org/resin-device-status/-/resin-device-status-1.1.1.tgz"
     },
     "resin-errors": {
       "version": "2.13.0",
-      "from": "resin-errors@>=2.9.0 <3.0.0",
+      "from": "resin-errors@^2.9.0",
       "resolved": "https://registry.npmjs.org/resin-errors/-/resin-errors-2.13.0.tgz",
       "dependencies": {
         "typed-error": {
           "version": "2.0.0",
-          "from": "typed-error@>=2.0.0 <3.0.0",
+          "from": "typed-error@^2.0.0",
           "resolved": "https://registry.npmjs.org/typed-error/-/typed-error-2.0.0.tgz"
         }
       }
     },
     "resin-pine": {
       "version": "5.0.4",
-      "from": "resin-pine@>=5.0.2 <6.0.0",
+      "from": "resin-pine@^5.0.2",
       "resolved": "https://registry.npmjs.org/resin-pine/-/resin-pine-5.0.4.tgz"
     },
     "resin-register-device": {
       "version": "4.1.1",
-      "from": "resin-register-device@>=4.0.1 <5.0.0",
+      "from": "resin-register-device@^4.0.1",
       "resolved": "https://registry.npmjs.org/resin-register-device/-/resin-register-device-4.1.1.tgz"
     },
     "resin-request": {
       "version": "8.6.0",
-      "from": "resin-request@>=8.6.0 <9.0.0",
+      "from": "resin-request@^8.6.0",
       "resolved": "https://registry.npmjs.org/resin-request/-/resin-request-8.6.0.tgz"
     },
     "resin-sdk": {
       "version": "6.15.0",
-      "from": "resin-sdk@>=6.4.1 <7.0.0",
+      "from": "resin-sdk@^6.4.1",
       "resolved": "https://registry.npmjs.org/resin-sdk/-/resin-sdk-6.15.0.tgz",
       "dependencies": {
         "semver": {
           "version": "5.6.0",
-          "from": "semver@>=5.3.0 <6.0.0",
+          "from": "semver@^5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz"
         }
       }
     },
     "resin-semver": {
       "version": "1.5.0",
-      "from": "resin-semver@>=1.4.0 <2.0.0",
+      "from": "resin-semver@^1.4.0",
       "resolved": "https://registry.npmjs.org/resin-semver/-/resin-semver-1.5.0.tgz",
       "dependencies": {
         "semver": {
           "version": "5.6.0",
-          "from": "semver@>=5.3.0 <6.0.0",
+          "from": "semver@^5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz"
         }
       }
     },
     "resin-settings-client": {
       "version": "3.8.8",
-      "from": "resin-settings-client@>=3.5.2 <4.0.0",
+      "from": "resin-settings-client@^3.5.2",
       "resolved": "https://registry.npmjs.org/resin-settings-client/-/resin-settings-client-3.8.8.tgz",
       "dependencies": {
         "@types/lodash": {
@@ -6648,56 +6648,56 @@
     },
     "resin-settings-storage": {
       "version": "4.0.1",
-      "from": "resin-settings-storage@>=4.0.0 <5.0.0",
+      "from": "resin-settings-storage@^4.0.0",
       "resolved": "https://registry.npmjs.org/resin-settings-storage/-/resin-settings-storage-4.0.1.tgz",
       "dependencies": {
         "@types/node": {
           "version": "8.10.40",
-          "from": "@types/node@>=8.0.19 <9.0.0",
+          "from": "@types/node@^8.0.19",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.40.tgz"
         }
       }
     },
     "resin-token": {
       "version": "4.2.1",
-      "from": "resin-token@>=4.0.0 <5.0.0",
+      "from": "resin-token@^4.0.0",
       "resolved": "https://registry.npmjs.org/resin-token/-/resin-token-4.2.1.tgz"
     },
     "resolve": {
       "version": "1.10.0",
-      "from": "resolve@>=1.10.0 <2.0.0",
+      "from": "resolve@^1.10.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz"
     },
     "resolve-dir": {
       "version": "0.1.1",
-      "from": "resolve-dir@>=0.1.0 <0.2.0",
+      "from": "resolve-dir@^0.1.0",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz"
     },
     "resolve-url": {
       "version": "0.2.1",
-      "from": "resolve-url@>=0.2.1 <0.3.0",
+      "from": "resolve-url@^0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "dev": true
     },
     "ret": {
       "version": "0.1.15",
-      "from": "ret@>=0.1.10 <0.2.0",
+      "from": "ret@~0.1.10",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "dev": true
     },
     "rimraf": {
       "version": "2.2.8",
-      "from": "rimraf@>=2.2.6 <2.3.0",
+      "from": "rimraf@~2.2.6",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
     },
     "rindle": {
       "version": "1.3.4",
-      "from": "rindle@>=1.3.1 <2.0.0",
+      "from": "rindle@^1.3.1",
       "resolved": "https://registry.npmjs.org/rindle/-/rindle-1.3.4.tgz"
     },
     "rmdir": {
       "version": "1.2.0",
-      "from": "rmdir@>=1.2.0 <2.0.0",
+      "from": "rmdir@^1.2.0",
       "resolved": "https://registry.npmjs.org/rmdir/-/rmdir-1.2.0.tgz"
     },
     "safe-buffer": {
@@ -6707,23 +6707,23 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "from": "safe-regex@>=1.1.0 <2.0.0",
+      "from": "safe-regex@^1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "from": "safer-buffer@>=2.1.2 <3.0.0",
+      "from": "safer-buffer@>= 2.1.2 < 3",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
     },
     "semver": {
       "version": "5.0.3",
-      "from": "semver@>=5.0.1 <5.1.0",
+      "from": "semver@~5.0.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
     },
     "semver-diff": {
       "version": "2.1.0",
-      "from": "semver-diff@>=2.0.0 <3.0.0",
+      "from": "semver-diff@^2.0.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "dev": true
     },
@@ -6734,14 +6734,14 @@
       "dependencies": {
         "statuses": {
           "version": "1.4.0",
-          "from": "statuses@>=1.4.0 <1.5.0",
+          "from": "statuses@~1.4.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz"
         }
       }
     },
     "sequencify": {
       "version": "0.0.7",
-      "from": "sequencify@>=0.0.7 <0.1.0",
+      "from": "sequencify@~0.0.7",
       "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
       "dev": true
     },
@@ -6752,17 +6752,17 @@
     },
     "set-blocking": {
       "version": "2.0.0",
-      "from": "set-blocking@>=2.0.0 <3.0.0",
+      "from": "set-blocking@^2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
     },
     "set-getter": {
       "version": "0.1.0",
-      "from": "set-getter@>=0.1.0 <0.2.0",
+      "from": "set-getter@^0.1.0",
       "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz"
     },
     "set-value": {
       "version": "2.0.0",
-      "from": "set-value@>=2.0.0 <3.0.0",
+      "from": "set-value@^2.0.0",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
       "dev": true
     },
@@ -6773,50 +6773,50 @@
     },
     "shebang-command": {
       "version": "1.2.0",
-      "from": "shebang-command@>=1.2.0 <2.0.0",
+      "from": "shebang-command@^1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz"
     },
     "shebang-regex": {
       "version": "1.0.0",
-      "from": "shebang-regex@>=1.0.0 <2.0.0",
+      "from": "shebang-regex@^1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
     },
     "shelljs": {
       "version": "0.7.8",
-      "from": "shelljs@>=0.7.0 <0.8.0",
+      "from": "shelljs@^0.7.0",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
       "dev": true
     },
     "sigmund": {
       "version": "1.0.1",
-      "from": "sigmund@>=1.0.0 <1.1.0",
+      "from": "sigmund@~1.0.0",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
-      "from": "signal-exit@>=3.0.0 <4.0.0",
+      "from": "signal-exit@^3.0.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
     },
     "slide": {
       "version": "1.1.6",
-      "from": "slide@>=1.1.5 <2.0.0",
+      "from": "slide@^1.1.5",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
     },
     "smart-buffer": {
       "version": "1.1.15",
-      "from": "smart-buffer@>=1.0.13 <2.0.0",
+      "from": "smart-buffer@^1.0.13",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz"
     },
     "snapdragon": {
       "version": "0.8.2",
-      "from": "snapdragon@>=0.8.1 <0.9.0",
+      "from": "snapdragon@^0.8.1",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "dev": true,
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "from": "source-map@>=0.5.6 <0.6.0",
+          "from": "source-map@^0.5.6",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "dev": true
         }
@@ -6824,43 +6824,43 @@
     },
     "snapdragon-node": {
       "version": "2.1.1",
-      "from": "snapdragon-node@>=2.0.1 <3.0.0",
+      "from": "snapdragon-node@^2.0.1",
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "dev": true,
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "from": "define-property@>=1.0.0 <2.0.0",
+          "from": "define-property@^1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "dev": true
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "from": "is-accessor-descriptor@>=1.0.0 <2.0.0",
+          "from": "is-accessor-descriptor@^1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "dev": true
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "from": "is-data-descriptor@>=1.0.0 <2.0.0",
+          "from": "is-data-descriptor@^1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "dev": true
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "from": "is-descriptor@>=1.0.0 <2.0.0",
+          "from": "is-descriptor@^1.0.0",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "dev": true
         },
         "isobject": {
           "version": "3.0.1",
-          "from": "isobject@>=3.0.0 <4.0.0",
+          "from": "isobject@^3.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "dev": true
         },
         "kind-of": {
           "version": "6.0.2",
-          "from": "kind-of@>=6.0.2 <7.0.0",
+          "from": "kind-of@^6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "dev": true
         }
@@ -6868,52 +6868,52 @@
     },
     "snapdragon-util": {
       "version": "3.0.1",
-      "from": "snapdragon-util@>=3.0.1 <4.0.0",
+      "from": "snapdragon-util@^3.0.1",
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "dev": true
     },
     "sntp": {
       "version": "1.0.9",
-      "from": "sntp@>=1.0.0 <2.0.0",
+      "from": "sntp@1.x.x",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
     },
     "socks": {
       "version": "1.1.10",
-      "from": "socks@>=1.1.10 <2.0.0",
+      "from": "socks@^1.1.10",
       "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz"
     },
     "socks-proxy-agent": {
       "version": "3.0.1",
-      "from": "socks-proxy-agent@>=3.0.0 <4.0.0",
+      "from": "socks-proxy-agent@^3.0.0",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz",
       "dependencies": {
         "agent-base": {
           "version": "4.2.1",
-          "from": "agent-base@>=4.1.0 <5.0.0",
+          "from": "agent-base@^4.1.0",
           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz"
         }
       }
     },
     "source-map": {
       "version": "0.6.1",
-      "from": "source-map@>=0.6.1 <0.7.0",
+      "from": "source-map@~0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
     },
     "source-map-resolve": {
       "version": "0.5.2",
-      "from": "source-map-resolve@>=0.5.0 <0.6.0",
+      "from": "source-map-resolve@^0.5.0",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "dev": true
     },
     "source-map-support": {
       "version": "0.4.18",
-      "from": "source-map-support@>=0.4.0 <0.5.0",
+      "from": "source-map-support@^0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "dev": true,
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "from": "source-map@>=0.5.6 <0.6.0",
+          "from": "source-map@^0.5.6",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "dev": true
         }
@@ -6921,56 +6921,56 @@
     },
     "source-map-url": {
       "version": "0.4.0",
-      "from": "source-map-url@>=0.4.0 <0.5.0",
+      "from": "source-map-url@^0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "dev": true
     },
     "sparkles": {
       "version": "1.0.1",
-      "from": "sparkles@>=1.0.0 <2.0.0",
+      "from": "sparkles@^1.0.0",
       "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
       "dev": true
     },
     "spdx-correct": {
       "version": "3.1.0",
-      "from": "spdx-correct@>=3.0.0 <4.0.0",
+      "from": "spdx-correct@^3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz"
     },
     "spdx-exceptions": {
       "version": "2.2.0",
-      "from": "spdx-exceptions@>=2.1.0 <3.0.0",
+      "from": "spdx-exceptions@^2.1.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz"
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
-      "from": "spdx-expression-parse@>=3.0.0 <4.0.0",
+      "from": "spdx-expression-parse@^3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz"
     },
     "spdx-license-ids": {
       "version": "3.0.3",
-      "from": "spdx-license-ids@>=3.0.0 <4.0.0",
+      "from": "spdx-license-ids@^3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz"
     },
     "speedometer": {
       "version": "1.0.0",
-      "from": "speedometer@>=1.0.0 <1.1.0",
+      "from": "speedometer@~1.0.0",
       "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.0.0.tgz"
     },
     "split-string": {
       "version": "3.1.0",
-      "from": "split-string@>=3.0.2 <4.0.0",
+      "from": "split-string@^3.0.2",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "dev": true,
       "dependencies": {
         "extend-shallow": {
           "version": "3.0.2",
-          "from": "extend-shallow@>=3.0.0 <4.0.0",
+          "from": "extend-shallow@^3.0.0",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "dev": true
         },
         "is-extendable": {
           "version": "1.0.1",
-          "from": "is-extendable@>=1.0.1 <2.0.0",
+          "from": "is-extendable@^1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "dev": true
         }
@@ -6978,131 +6978,131 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "from": "sprintf-js@>=1.0.2 <1.1.0",
+      "from": "sprintf-js@~1.0.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
     },
     "sshpk": {
       "version": "1.16.1",
-      "from": "sshpk@>=1.7.0 <2.0.0",
+      "from": "sshpk@^1.7.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "dependencies": {
         "asn1": {
           "version": "0.2.4",
-          "from": "asn1@>=0.2.3 <0.3.0",
+          "from": "asn1@~0.2.3",
           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz"
         },
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "from": "assert-plus@^1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "static-extend": {
       "version": "0.1.2",
-      "from": "static-extend@>=0.1.1 <0.2.0",
+      "from": "static-extend@^0.1.1",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "dev": true
     },
     "statuses": {
       "version": "1.5.0",
-      "from": "statuses@>=1.4.0 <2.0.0",
+      "from": "statuses@>= 1.4.0 < 2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz"
     },
     "stealthy-require": {
       "version": "1.1.1",
-      "from": "stealthy-require@>=1.1.1 <2.0.0",
+      "from": "stealthy-require@^1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz"
     },
     "stream-consume": {
       "version": "0.1.1",
-      "from": "stream-consume@>=0.1.0 <0.2.0",
+      "from": "stream-consume@^0.1.0",
       "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz"
     },
     "stream-shift": {
       "version": "1.0.0",
-      "from": "stream-shift@>=1.0.0 <2.0.0",
+      "from": "stream-shift@^1.0.0",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "dev": true
     },
     "string_decoder": {
       "version": "0.10.31",
-      "from": "string_decoder@>=0.10.0 <0.11.0",
+      "from": "string_decoder@~0.10.x",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
     },
     "string-to-stream": {
       "version": "1.1.1",
-      "from": "string-to-stream@>=1.0.1 <2.0.0",
+      "from": "string-to-stream@^1.0.1",
       "resolved": "https://registry.npmjs.org/string-to-stream/-/string-to-stream-1.1.1.tgz",
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
+          "from": "isarray@~1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "from": "process-nextick-args@>=2.0.0 <2.1.0",
+          "from": "process-nextick-args@~2.0.0",
           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.3.6",
-          "from": "readable-stream@>=2.1.0 <3.0.0",
+          "from": "readable-stream@^2.1.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz"
         },
         "string_decoder": {
           "version": "1.1.1",
-          "from": "string_decoder@>=1.1.1 <1.2.0",
+          "from": "string_decoder@~1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
         }
       }
     },
     "string-width": {
       "version": "2.1.1",
-      "from": "string-width@>=2.0.0 <3.0.0",
+      "from": "string-width@^2.0.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "from": "ansi-regex@>=3.0.0 <4.0.0",
+          "from": "ansi-regex@^3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
+          "from": "is-fullwidth-code-point@^2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "from": "strip-ansi@>=4.0.0 <5.0.0",
+          "from": "strip-ansi@^4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
         }
       }
     },
     "stringstream": {
       "version": "0.0.6",
-      "from": "stringstream@>=0.0.4 <0.1.0",
+      "from": "stringstream@~0.0.4",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz"
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "from": "strip-ansi@>=3.0.0 <4.0.0",
+      "from": "strip-ansi@^3.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
     },
     "strip-bom": {
       "version": "3.0.0",
-      "from": "strip-bom@>=3.0.0 <4.0.0",
+      "from": "strip-bom@^3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
     },
     "strip-bom-stream": {
       "version": "1.0.0",
-      "from": "strip-bom-stream@>=1.0.0 <2.0.0",
+      "from": "strip-bom-stream@^1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
       "dev": true,
       "dependencies": {
         "strip-bom": {
           "version": "2.0.0",
-          "from": "strip-bom@>=2.0.0 <3.0.0",
+          "from": "strip-bom@^2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "dev": true
         }
@@ -7110,39 +7110,39 @@
     },
     "strip-bom-string": {
       "version": "1.0.0",
-      "from": "strip-bom-string@>=1.0.0 <2.0.0",
+      "from": "strip-bom-string@1.X",
       "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
       "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",
-      "from": "strip-eof@>=1.0.0 <2.0.0",
+      "from": "strip-eof@^1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz"
     },
     "strip-json-comments": {
       "version": "2.0.1",
-      "from": "strip-json-comments@>=2.0.1 <2.1.0",
+      "from": "strip-json-comments@~2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "dev": true
     },
     "striptags": {
       "version": "2.2.1",
-      "from": "striptags@>=2.1.1 <3.0.0",
+      "from": "striptags@^2.1.1",
       "resolved": "https://registry.npmjs.org/striptags/-/striptags-2.2.1.tgz"
     },
     "superagent": {
       "version": "2.3.0",
-      "from": "superagent@>=2.3.0 <3.0.0",
+      "from": "superagent@^2.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-2.3.0.tgz",
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "from": "async@>=1.5.2 <2.0.0",
+          "from": "async@^1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "extend": {
           "version": "3.0.2",
-          "from": "extend@>=3.0.0 <4.0.0",
+          "from": "extend@^3.0.0",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
         },
         "form-data": {
@@ -7152,46 +7152,46 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
+          "from": "isarray@~1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "from": "process-nextick-args@>=2.0.0 <2.1.0",
+          "from": "process-nextick-args@~2.0.0",
           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.3.6",
-          "from": "readable-stream@>=2.0.5 <3.0.0",
+          "from": "readable-stream@^2.0.5",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz"
         },
         "string_decoder": {
           "version": "1.1.1",
-          "from": "string_decoder@>=1.1.1 <1.2.0",
+          "from": "string_decoder@~1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
         }
       }
     },
     "superagent-proxy": {
       "version": "1.0.3",
-      "from": "superagent-proxy@>=1.0.2 <2.0.0",
+      "from": "superagent-proxy@^1.0.2",
       "resolved": "https://registry.npmjs.org/superagent-proxy/-/superagent-proxy-1.0.3.tgz",
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "from": "debug@>=3.1.0 <4.0.0",
+          "from": "debug@^3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz"
         },
         "ms": {
           "version": "2.1.1",
-          "from": "ms@>=2.1.1 <3.0.0",
+          "from": "ms@^2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz"
         }
       }
     },
     "supports-color": {
       "version": "2.0.0",
-      "from": "supports-color@>=2.0.0 <3.0.0",
+      "from": "supports-color@^2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
     },
     "taffydb": {
@@ -7202,24 +7202,24 @@
     },
     "temp": {
       "version": "0.8.3",
-      "from": "temp@>=0.8.3 <0.9.0",
+      "from": "temp@^0.8.3",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz"
     },
     "term-size": {
       "version": "1.2.0",
-      "from": "term-size@>=1.2.0 <2.0.0",
+      "from": "term-size@^1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
       "dev": true,
       "dependencies": {
         "cross-spawn": {
           "version": "5.1.0",
-          "from": "cross-spawn@>=5.0.1 <6.0.0",
+          "from": "cross-spawn@^5.0.1",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "dev": true
         },
         "execa": {
           "version": "0.7.0",
-          "from": "execa@>=0.7.0 <0.8.0",
+          "from": "execa@^0.7.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "dev": true
         }
@@ -7227,80 +7227,80 @@
     },
     "through": {
       "version": "2.3.8",
-      "from": "through@>=2.3.8 <2.4.0",
+      "from": "through@~2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "dev": true
     },
     "through2": {
       "version": "2.0.5",
-      "from": "through2@>=2.0.3 <2.1.0",
+      "from": "through2@~2.0.3",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
+          "from": "isarray@~1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "from": "process-nextick-args@>=2.0.0 <2.1.0",
+          "from": "process-nextick-args@~2.0.0",
           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.3.6",
-          "from": "readable-stream@>=2.3.6 <2.4.0",
+          "from": "readable-stream@~2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz"
         },
         "string_decoder": {
           "version": "1.1.1",
-          "from": "string_decoder@>=1.1.1 <1.2.0",
+          "from": "string_decoder@~1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
         }
       }
     },
     "through2-filter": {
       "version": "2.0.0",
-      "from": "through2-filter@>=2.0.0 <3.0.0",
+      "from": "through2-filter@^2.0.0",
       "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
       "dev": true
     },
     "thunkify": {
       "version": "2.1.2",
-      "from": "thunkify@>=2.1.2 <3.0.0",
+      "from": "thunkify@^2.1.2",
       "resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz"
     },
     "tildify": {
       "version": "1.2.0",
-      "from": "tildify@>=1.0.0 <2.0.0",
+      "from": "tildify@^1.0.0",
       "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
       "dev": true
     },
     "time-stamp": {
       "version": "1.1.0",
-      "from": "time-stamp@>=1.0.0 <2.0.0",
+      "from": "time-stamp@^1.0.0",
       "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
       "dev": true
     },
     "timed-out": {
       "version": "4.0.1",
-      "from": "timed-out@>=4.0.0 <5.0.0",
+      "from": "timed-out@^4.0.0",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "dev": true
     },
     "timers-ext": {
       "version": "0.1.7",
-      "from": "timers-ext@>=0.1.5 <0.2.0",
+      "from": "timers-ext@^0.1.5",
       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz"
     },
     "to-absolute-glob": {
       "version": "0.1.1",
-      "from": "to-absolute-glob@>=0.1.1 <0.2.0",
+      "from": "to-absolute-glob@^0.1.1",
       "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
       "dev": true
     },
     "to-file": {
       "version": "0.2.0",
-      "from": "to-file@>=0.2.0 <0.3.0",
+      "from": "to-file@^0.2.0",
       "resolved": "https://registry.npmjs.org/to-file/-/to-file-0.2.0.tgz",
       "dependencies": {
         "isarray": {
@@ -7310,72 +7310,72 @@
         },
         "isobject": {
           "version": "2.1.0",
-          "from": "isobject@>=2.1.0 <3.0.0",
+          "from": "isobject@^2.1.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
         }
       }
     },
     "to-gfm-code-block": {
       "version": "0.1.1",
-      "from": "to-gfm-code-block@>=0.1.1 <0.2.0",
+      "from": "to-gfm-code-block@^0.1.1",
       "resolved": "https://registry.npmjs.org/to-gfm-code-block/-/to-gfm-code-block-0.1.1.tgz"
     },
     "to-object-path": {
       "version": "0.3.0",
-      "from": "to-object-path@>=0.3.0 <0.4.0",
+      "from": "to-object-path@^0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz"
     },
     "to-regex": {
       "version": "3.0.2",
-      "from": "to-regex@>=3.0.2 <4.0.0",
+      "from": "to-regex@^3.0.2",
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "dev": true,
       "dependencies": {
         "define-property": {
           "version": "2.0.2",
-          "from": "define-property@>=2.0.2 <3.0.0",
+          "from": "define-property@^2.0.2",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
           "dev": true
         },
         "extend-shallow": {
           "version": "3.0.2",
-          "from": "extend-shallow@>=3.0.2 <4.0.0",
+          "from": "extend-shallow@^3.0.2",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "dev": true
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "from": "is-accessor-descriptor@>=1.0.0 <2.0.0",
+          "from": "is-accessor-descriptor@^1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "dev": true
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "from": "is-data-descriptor@>=1.0.0 <2.0.0",
+          "from": "is-data-descriptor@^1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "dev": true
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "from": "is-descriptor@>=1.0.2 <2.0.0",
+          "from": "is-descriptor@^1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "dev": true
         },
         "is-extendable": {
           "version": "1.0.1",
-          "from": "is-extendable@>=1.0.1 <2.0.0",
+          "from": "is-extendable@^1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "dev": true
         },
         "isobject": {
           "version": "3.0.1",
-          "from": "isobject@>=3.0.1 <4.0.0",
+          "from": "isobject@^3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "dev": true
         },
         "kind-of": {
           "version": "6.0.2",
-          "from": "kind-of@>=6.0.2 <7.0.0",
+          "from": "kind-of@^6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "dev": true
         }
@@ -7383,13 +7383,13 @@
     },
     "to-regex-range": {
       "version": "2.1.1",
-      "from": "to-regex-range@>=2.1.0 <3.0.0",
+      "from": "to-regex-range@^2.1.0",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "dev": true,
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
-          "from": "is-number@>=3.0.0 <4.0.0",
+          "from": "is-number@^3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "dev": true
         }
@@ -7397,17 +7397,17 @@
     },
     "topo": {
       "version": "1.1.0",
-      "from": "topo@>=1.0.0 <2.0.0",
+      "from": "topo@1.x.x",
       "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz"
     },
     "touch": {
       "version": "1.0.0",
-      "from": "touch@>=1.0.0 <2.0.0",
+      "from": "touch@^1.0.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
       "dependencies": {
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@>=1.0.10 <1.1.0",
+          "from": "nopt@~1.0.10",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
         }
       }
@@ -7419,37 +7419,37 @@
     },
     "ts-node": {
       "version": "3.3.0",
-      "from": "ts-node@>=3.3.0 <4.0.0",
+      "from": "ts-node@^3.3.0",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-3.3.0.tgz",
       "dev": true,
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "from": "ansi-styles@>=3.2.1 <4.0.0",
+          "from": "ansi-styles@^3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "dev": true
         },
         "chalk": {
           "version": "2.4.2",
-          "from": "chalk@>=2.0.0 <3.0.0",
+          "from": "chalk@^2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "dev": true
         },
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.2.0 <2.0.0",
+          "from": "minimist@^1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
-          "from": "supports-color@>=5.3.0 <6.0.0",
+          "from": "supports-color@^5.3.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "dev": true
         },
         "v8flags": {
           "version": "3.1.2",
-          "from": "v8flags@>=3.0.0 <4.0.0",
+          "from": "v8flags@^3.0.0",
           "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.2.tgz",
           "dev": true
         }
@@ -7457,30 +7457,30 @@
     },
     "tsconfig": {
       "version": "6.0.0",
-      "from": "tsconfig@>=6.0.0 <7.0.0",
+      "from": "tsconfig@^6.0.0",
       "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-6.0.0.tgz",
       "dev": true
     },
     "tslib": {
       "version": "1.9.3",
-      "from": "tslib@>=1.7.1 <2.0.0",
+      "from": "tslib@^1.7.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz"
     },
     "tslint": {
       "version": "4.5.1",
-      "from": "tslint@>=4.5.1 <5.0.0",
+      "from": "tslint@^4.5.1",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
       "dev": true,
       "dependencies": {
         "findup-sync": {
           "version": "0.3.0",
-          "from": "findup-sync@>=0.3.0 <0.4.0",
+          "from": "findup-sync@~0.3.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
           "dev": true,
           "dependencies": {
             "glob": {
               "version": "5.0.15",
-              "from": "glob@>=5.0.0 <5.1.0",
+              "from": "glob@~5.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
               "dev": true
             }
@@ -7490,39 +7490,39 @@
     },
     "tsutils": {
       "version": "1.9.1",
-      "from": "tsutils@>=1.1.0 <2.0.0",
+      "from": "tsutils@^1.1.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-1.9.1.tgz",
       "dev": true
     },
     "tunnel-agent": {
       "version": "0.4.3",
-      "from": "tunnel-agent@>=0.4.0 <0.5.0",
+      "from": "tunnel-agent@~0.4.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "from": "tweetnacl@>=0.14.0 <0.15.0",
+      "from": "tweetnacl@~0.14.0",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
     },
     "type-check": {
       "version": "0.3.2",
-      "from": "type-check@>=0.3.2 <0.4.0",
+      "from": "type-check@~0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
     },
     "type-detect": {
       "version": "4.0.8",
-      "from": "type-detect@>=4.0.5 <5.0.0",
+      "from": "type-detect@^4.0.5",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "dev": true
     },
     "type-is": {
       "version": "1.6.16",
-      "from": "type-is@>=1.6.16 <1.7.0",
+      "from": "type-is@~1.6.16",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz"
     },
     "typed-error": {
       "version": "1.1.1",
-      "from": "typed-error@>=1.0.1 <2.0.0",
+      "from": "typed-error@^1.0.1",
       "resolved": "https://registry.npmjs.org/typed-error/-/typed-error-1.1.1.tgz"
     },
     "typedoc": {
@@ -7541,25 +7541,25 @@
     },
     "typedoc-default-themes": {
       "version": "0.5.0",
-      "from": "typedoc-default-themes@>=0.5.0 <0.6.0",
+      "from": "typedoc-default-themes@^0.5.0",
       "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
       "dev": true
     },
     "typescript": {
       "version": "2.9.2",
-      "from": "typescript@>=2.9.2 <2.10.0",
+      "from": "typescript@~2.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
       "dev": true
     },
     "uglify-js": {
       "version": "3.4.9",
-      "from": "uglify-js@>=3.1.4 <4.0.0",
+      "from": "uglify-js@^3.1.4",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
       "optional": true,
       "dependencies": {
         "commander": {
           "version": "2.17.1",
-          "from": "commander@>=2.17.1 <2.18.0",
+          "from": "commander@~2.17.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
           "optional": true
         }
@@ -7567,17 +7567,17 @@
     },
     "unc-path-regex": {
       "version": "0.1.2",
-      "from": "unc-path-regex@>=0.1.0 <0.2.0",
+      "from": "unc-path-regex@^0.1.0",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz"
     },
     "underscore": {
       "version": "1.7.0",
-      "from": "underscore@>=1.7.0 <1.8.0",
+      "from": "underscore@~1.7.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
     },
     "underscore-contrib": {
       "version": "0.3.0",
-      "from": "underscore-contrib@>=0.3.0 <0.4.0",
+      "from": "underscore-contrib@~0.3.0",
       "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
       "dev": true,
       "dependencies": {
@@ -7591,18 +7591,18 @@
     },
     "underscore.string": {
       "version": "3.3.5",
-      "from": "underscore.string@>=3.3.4 <3.4.0",
+      "from": "underscore.string@~3.3.4",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz"
     },
     "union-value": {
       "version": "1.0.0",
-      "from": "union-value@>=1.0.0 <2.0.0",
+      "from": "union-value@^1.0.0",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
       "dev": true,
       "dependencies": {
         "set-value": {
           "version": "0.4.3",
-          "from": "set-value@>=0.4.3 <0.5.0",
+          "from": "set-value@^0.4.3",
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "dev": true
         }
@@ -7610,24 +7610,24 @@
     },
     "unique-stream": {
       "version": "1.0.0",
-      "from": "unique-stream@>=1.0.0 <2.0.0",
+      "from": "unique-stream@^1.0.0",
       "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
       "dev": true
     },
     "unique-string": {
       "version": "1.0.0",
-      "from": "unique-string@>=1.0.0 <2.0.0",
+      "from": "unique-string@^1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "dev": true
     },
     "universal-user-agent": {
       "version": "2.0.3",
-      "from": "universal-user-agent@>=2.0.0 <3.0.0",
+      "from": "universal-user-agent@^2.0.0",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.3.tgz"
     },
     "universalify": {
       "version": "0.1.2",
-      "from": "universalify@>=0.1.0 <0.2.0",
+      "from": "universalify@^0.1.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "dev": true
     },
@@ -7638,19 +7638,19 @@
     },
     "unset-value": {
       "version": "1.0.0",
-      "from": "unset-value@>=1.0.0 <2.0.0",
+      "from": "unset-value@^1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "dev": true,
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
-          "from": "has-value@>=0.3.1 <0.4.0",
+          "from": "has-value@^0.3.1",
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "dev": true,
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
-              "from": "isobject@>=2.0.0 <3.0.0",
+              "from": "isobject@^2.0.0",
               "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
               "dev": true
             }
@@ -7664,7 +7664,7 @@
         },
         "isobject": {
           "version": "3.0.1",
-          "from": "isobject@>=3.0.0 <4.0.0",
+          "from": "isobject@^3.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "dev": true
         }
@@ -7672,7 +7672,7 @@
     },
     "unzip-response": {
       "version": "2.0.1",
-      "from": "unzip-response@>=2.0.1 <3.0.0",
+      "from": "unzip-response@^2.0.1",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
       "dev": true
     },
@@ -7683,32 +7683,32 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "from": "async@>=1.5.2 <2.0.0",
+          "from": "async@^1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         }
       }
     },
     "update-notifier": {
       "version": "2.5.0",
-      "from": "update-notifier@>=2.0.0 <3.0.0",
+      "from": "update-notifier@^2.0.0",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
       "dev": true,
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "from": "ansi-styles@>=3.2.1 <4.0.0",
+          "from": "ansi-styles@^3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "dev": true
         },
         "chalk": {
           "version": "2.4.2",
-          "from": "chalk@>=2.0.1 <3.0.0",
+          "from": "chalk@^2.0.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
-          "from": "supports-color@>=5.3.0 <6.0.0",
+          "from": "supports-color@^5.3.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "dev": true
         }
@@ -7716,41 +7716,41 @@
     },
     "uri-js": {
       "version": "4.2.2",
-      "from": "uri-js@>=4.2.2 <5.0.0",
+      "from": "uri-js@^4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz"
     },
     "urix": {
       "version": "0.1.0",
-      "from": "urix@>=0.1.0 <0.2.0",
+      "from": "urix@^0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "dev": true
     },
     "url-parse-lax": {
       "version": "1.0.0",
-      "from": "url-parse-lax@>=1.0.0 <2.0.0",
+      "from": "url-parse-lax@^1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "dev": true
     },
     "url-template": {
       "version": "2.0.8",
-      "from": "url-template@>=2.0.8 <3.0.0",
+      "from": "url-template@^2.0.8",
       "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz"
     },
     "use": {
       "version": "3.1.1",
-      "from": "use@>=3.1.0 <4.0.0",
+      "from": "use@^3.1.0",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "dev": true
     },
     "user-home": {
       "version": "1.1.1",
-      "from": "user-home@>=1.1.1 <2.0.0",
+      "from": "user-home@^1.1.1",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
       "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "from": "util-deprecate@>=1.0.1 <1.1.0",
+      "from": "util-deprecate@~1.0.1",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
     },
     "utils-merge": {
@@ -7760,24 +7760,24 @@
     },
     "v8flags": {
       "version": "2.1.1",
-      "from": "v8flags@>=2.0.2 <3.0.0",
+      "from": "v8flags@^2.0.2",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
       "dev": true
     },
     "vali-date": {
       "version": "1.0.0",
-      "from": "vali-date@>=1.0.0 <2.0.0",
+      "from": "vali-date@^1.0.0",
       "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
       "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
-      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+      "from": "validate-npm-package-license@^3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz"
     },
     "vary": {
       "version": "1.1.2",
-      "from": "vary@>=1.1.2 <1.2.0",
+      "from": "vary@~1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
     },
     "verror": {
@@ -7787,14 +7787,14 @@
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "from": "assert-plus@^1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "versionist": {
       "version": "2.18.0",
-      "from": "versionist@>=2.13.0 <3.0.0",
+      "from": "versionist@^2.13.0",
       "resolved": "https://registry.npmjs.org/versionist/-/versionist-2.18.0.tgz",
       "dependencies": {
         "debug": {
@@ -7809,49 +7809,49 @@
         },
         "semver": {
           "version": "5.6.0",
-          "from": "semver@>=5.2.0 <6.0.0",
+          "from": "semver@^5.2.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz"
         }
       }
     },
     "vinyl": {
       "version": "1.2.0",
-      "from": "vinyl@>=1.1.1 <2.0.0",
+      "from": "vinyl@^1.1.1",
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz"
     },
     "vinyl-fs": {
       "version": "0.3.14",
-      "from": "vinyl-fs@>=0.3.0 <0.4.0",
+      "from": "vinyl-fs@^0.3.0",
       "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
       "dev": true,
       "dependencies": {
         "clone": {
           "version": "0.2.0",
-          "from": "clone@>=0.2.0 <0.3.0",
+          "from": "clone@^0.2.0",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "dev": true
         },
         "graceful-fs": {
           "version": "3.0.11",
-          "from": "graceful-fs@>=3.0.0 <4.0.0",
+          "from": "graceful-fs@^3.0.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
           "dev": true
         },
         "strip-bom": {
           "version": "1.0.0",
-          "from": "strip-bom@>=1.0.0 <2.0.0",
+          "from": "strip-bom@^1.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
           "dev": true
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.1 <0.7.0",
+          "from": "through2@^0.6.1",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dev": true
         },
         "vinyl": {
           "version": "0.4.6",
-          "from": "vinyl@>=0.4.0 <0.5.0",
+          "from": "vinyl@^0.4.0",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "dev": true
         }
@@ -7859,61 +7859,61 @@
     },
     "which": {
       "version": "1.3.1",
-      "from": "which@>=1.2.9 <2.0.0",
+      "from": "which@^1.2.9",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz"
     },
     "which-module": {
       "version": "2.0.0",
-      "from": "which-module@>=2.0.0 <3.0.0",
+      "from": "which-module@^2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz"
     },
     "widest-line": {
       "version": "2.0.1",
-      "from": "widest-line@>=2.0.0 <3.0.0",
+      "from": "widest-line@^2.0.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
       "dev": true
     },
     "windows-release": {
       "version": "3.1.0",
-      "from": "windows-release@>=3.1.0 <4.0.0",
+      "from": "windows-release@^3.1.0",
       "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.1.0.tgz"
     },
     "wordwrap": {
       "version": "1.0.0",
-      "from": "wordwrap@>=1.0.0 <1.1.0",
+      "from": "wordwrap@~1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "from": "wrap-ansi@>=2.0.0 <3.0.0",
+      "from": "wrap-ansi@^2.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "dependencies": {
         "string-width": {
           "version": "1.0.2",
-          "from": "string-width@>=1.0.1 <2.0.0",
+          "from": "string-width@^1.0.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
         }
       }
     },
     "wrappy": {
       "version": "1.0.2",
-      "from": "wrappy@>=1.0.0 <2.0.0",
+      "from": "wrappy@1",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
     },
     "write-file-atomic": {
       "version": "1.3.4",
-      "from": "write-file-atomic@>=1.1.4 <2.0.0",
+      "from": "write-file-atomic@^1.1.4",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz"
     },
     "xdg-basedir": {
       "version": "3.0.0",
-      "from": "xdg-basedir@>=3.0.0 <4.0.0",
+      "from": "xdg-basedir@^3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "dev": true
     },
     "xmlcreate": {
       "version": "1.0.2",
-      "from": "xmlcreate@>=1.0.1 <2.0.0",
+      "from": "xmlcreate@^1.0.1",
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
       "dev": true
     },
@@ -7924,64 +7924,64 @@
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.0 <5.0.0",
+      "from": "xtend@^4.0.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
     "y18n": {
       "version": "3.2.1",
-      "from": "y18n@>=3.2.1 <4.0.0",
+      "from": "y18n@^3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
     },
     "yallist": {
       "version": "2.1.2",
-      "from": "yallist@>=2.1.2 <3.0.0",
+      "from": "yallist@^2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
     },
     "yamljs": {
       "version": "0.2.10",
-      "from": "yamljs@>=0.2.8 <0.3.0",
+      "from": "yamljs@^0.2.8",
       "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.2.10.tgz"
     },
     "yargs": {
       "version": "11.1.0",
-      "from": "yargs@>=11.1.0 <12.0.0",
+      "from": "yargs@^11.1.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "from": "ansi-regex@>=3.0.0 <4.0.0",
+          "from": "ansi-regex@^3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
         },
         "camelcase": {
           "version": "4.1.0",
-          "from": "camelcase@>=4.1.0 <5.0.0",
+          "from": "camelcase@^4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
         },
         "cliui": {
           "version": "4.1.0",
-          "from": "cliui@>=4.0.0 <5.0.0",
+          "from": "cliui@^4.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz"
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "from": "strip-ansi@>=4.0.0 <5.0.0",
+          "from": "strip-ansi@^4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
         },
         "yargs-parser": {
           "version": "9.0.2",
-          "from": "yargs-parser@>=9.0.2 <10.0.0",
+          "from": "yargs-parser@^9.0.2",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz"
         }
       }
     },
     "yargs-parser": {
       "version": "2.4.1",
-      "from": "yargs-parser@>=2.4.0 <3.0.0",
+      "from": "yargs-parser@^2.4.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz"
     },
     "yn": {
       "version": "2.0.0",
-      "from": "yn@>=2.0.0 <3.0.0",
+      "from": "yn@^2.0.0",
       "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
       "dev": true
     }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "emailreplyparser": "0.0.5",
     "express": "^4.0.34",
     "flowdock": "github:balena-io-playground/node-flowdock#emit-error-response",
-    "front-sdk": "^0.3.1",
+    "front-sdk": "^0.6.0",
     "github": "9.2.0",
     "github-webhook-handler": "^0.6.0",
     "hmac": "^1.0.1",


### PR DESCRIPTION
The upstream front-sdk dependency used some updated endpoints based on the Front API (e.g. [using`page_token` instead of `page`](https://github.com/balena-io-modules/front-sdk/commit/261a9019e49331133df0d7b0b72f9568c834b733#diff-13b5b151431c7e7a17f273559ed212d5) , as the current Front API docs suggest.

This probably causes issues related to linking and searching conversations, as there functions depend on getting paginated results.


Change-type: patch
Signed-off-by: Kostas Lekkas <kostas@balena.io>
