### PR TITLE
lib/services/messenger/translators/front: Fix fetchContactName

### DIFF
--- a/lib/services/messenger/translators/front.ts
+++ b/lib/services/messenger/translators/front.ts
@@ -201,7 +201,11 @@ export class FrontTranslator extends TranslatorScaffold implements Translator {
 	 * @returns           Promise that resolves to the name of the contact.
 	 */
 	private static fetchContactName(session: Front, contactUrl: string): Promise<string> {
-		return session.getFromLink(contactUrl)
+		// HACK
+		// replacing the https://resin.io.api.frontapp.com URL with
+		// https://api2.frontapp.com
+		const correctUrl = contactUrl.replace('https://resin.io.api.frontapp.com', 'https://api2.frontapp.com');
+		return session.getFromLink(correctUrl)
 		.then((contact: Contact) => {
 			return contact.name || contact.handles[0].handle;
 		});


### PR DESCRIPTION
fetchContactName fails because the front-sdk's method getFromLink
malforms the URL it uses to request the contact from Front.
See here https://github.com/balena-io-modules/front-sdk/blob/800205025e8ff8946fbd0908ec1003afdabbc9e4/lib/index.ts#L434
The malformed URL looks like
https://api2.frontapp.com/https://resin.io.api.frontapp.com/contacts/<contact_id>
instead it should be
https://api2.frontapp.com/contacts/<contact_id>
  